### PR TITLE
Exporting Streamlist

### DIFF
--- a/youtube.go
+++ b/youtube.go
@@ -20,7 +20,7 @@ func NewYoutube() *Youtube {
 type stream map[string]string
 
 type Youtube struct {
-	streamList []stream
+	StreamList []stream
 	videoID    string
 	videoInfo  string
 }


### PR DESCRIPTION
Making the `streamlist` uppercase allows accessing video information, like the Title, Author etc. This would also allow someone to easily continue using the downloaded file, as there is currently no way of knowing the filename of the downloaded file.