### PR TITLE
Add Http timeout

### DIFF
--- a/youtube.go
+++ b/youtube.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"golang.org/x/net/proxy"
 )
@@ -273,7 +275,15 @@ func (y *Youtube) parseVideoInfo() error {
 
 func (y *Youtube) getHTTPClient() (*http.Client, error) {
 	// setup a http client
-	httpTransport := &http.Transport{}
+	httpTransport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		IdleConnTimeout:       60 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 	httpClient := &http.Client{Transport: httpTransport}
 
 	if len(y.Socks5Proxy) == 0 {


### PR DESCRIPTION
## Description 
Go's http package doesn't specify request timeout by default.
Adding client-side timeouts is good for us to detect if there is a
server-side issues.

## How
Add timeout config according to https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/