### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ test-unit:
 	@go test -v
 
 .PHONY: test-integration
-test-integration: ## Runs all Youtube Go unit tests
+test-integration: ## Runs all Youtube Go integration tests
 test-integration:
 	@go test -v -tags="integration"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+FILES_TO_FMT      ?= $(shell find . -path ./vendor -prune -o -name '*.go' -print)
+
+GOFLAGS   :=
+LDFLAGS   :=
+
+BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+GITSHA := $(shell git rev-parse --short HEAD 2>/dev/null)
+
+ifndef VERSION
+	VERSION := git-$(GITSHA)
+endif
+
+GOFLAGS += -trimpath
+
+LDFLAGS += -X $(PKG)/version.version=$(VERSION)
+LDFLAGS += -X $(PKG)/version.commit=$(GITSHA)
+LDFLAGS += -X $(PKG)/version.buildTime=$(BUILDTIME)
+
+.PHONY: build
+build:
+	@go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o ./bin ./...
+
+.PHONY: deps
+deps: ## Ensures fresh go.mod and go.sum.
+	@go mod tidy
+	@go mod verify
+
+.PHONY: lint
+lint:
+	@if [ ! -f ./bin/golangci-lint ]; then \
+		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s $(GOLANGCI_LINT_VERSION); \
+	fi;
+	@echo "golangci-lint checking..."
+	@./bin/golangci-lint run --deadline=30m --enable=misspell --enable=gosec --enable=gofmt --enable=goimports ./cmd/... ./...
+	@go vet ./...
+
+.PHONY: format
+format: ## Formats Go code
+	@echo ">> formatting code"
+	@gofmt -s -w $(FILES_TO_FMT)
+
+.PHONY: test-unit
+test-unit: ## Runs all Youtube Go unit tests
+test-unit:
+	@go test -v
+
+.PHONY: test-integration
+test-integration: ## Runs all Youtube Go unit tests
+test-integration:
+	@go test -v -tags="integration"


### PR DESCRIPTION
[Why]
1. To make ppl easier to understand how to build, lint, and test this
project.
2. make workflow reproducible

[How]
1. Add Makefile
2. Add several stages including:
    - deps: Ensures fresh go.mod and go.sum.
    - lint: adopt golangci-lint to improve code quality
    - format: Formats Go code
    - test-unit: run unit tests
    - test-integration: run integration tests