### PR TITLE
Show default usage hint when user types wrong command

### DIFF
--- a/youtubedr/main.go
+++ b/youtubedr/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"os/user"
 	"path/filepath"
 
@@ -40,7 +41,12 @@ func main() {
 	flag.BoolVar(&itags, "itags", false, "list available itags of video")
 
 	flag.Parse()
-	log.Println(flag.Args())
+
+	if len(flag.Args()) == 0 {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
 	log.Println("download to dir=", outputDir)
 	y := NewYoutubeWithSocks5Proxy(true, socks5Proxy)
 	if len(y.Socks5Proxy) == 0 {


### PR DESCRIPTION
# Description

Let user know how to use this tool when they forget to type arguments

## Issues to fix

Please link issues this PR will fix: \
https://github.com/kkdai/youtube/issues/55

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
