### PR TITLE
Fix github actions naming issue

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,7 +37,7 @@ jobs:
         platform: [ubuntu-18.04]
         go-version: [1.13.x]
     runs-on: ${{ matrix.platform }}
-    name: Thanos end-to-end tests
+    name: integration tests
     env:
       GOBIN: /tmp/.bin
     steps:


### PR DESCRIPTION
# Description

We copy this GitHub actions from Thanos project so that we forget renaming the action name.


## Issues to fix

Please link issues this PR will fix: \
\#_[issue number]_

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
