### PR TITLE
Add InsecureSkipVerify argument to skip server certificate verification

### DIFF
--- a/download_test.go
+++ b/download_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDownloadFromYT_AssignOutputFileName(t *testing.T) {
-	y := NewYoutube(false)
+	y := NewYoutube(false, false)
 	if y == nil {
 		t.Error("Cannot init object.")
 		return
@@ -54,7 +54,7 @@ func TestDownloadFromYT_AssignOutputFileName(t *testing.T) {
 }
 
 func TestDownloadFromYT_NoOutputFileName(t *testing.T) {
-	y := NewYoutube(false)
+	y := NewYoutube(false, false)
 	if y == nil {
 		t.Error("Cannot init object.")
 		return
@@ -76,7 +76,7 @@ func TestDownloadFromYT_NoOutputFileName(t *testing.T) {
 }
 
 func TestDownloadFromYT_HighQuality(t *testing.T) {
-	y := NewYoutube(false)
+	y := NewYoutube(false, false)
 	if y == nil {
 		t.Error("Cannot init object.")
 		return
@@ -98,7 +98,7 @@ func TestDownloadFromYT_HighQuality(t *testing.T) {
 }
 
 func TestDownloadFromYT_WithItag(t *testing.T) {
-	y := NewYoutube(false)
+	y := NewYoutube(false, false)
 	if y == nil {
 		t.Error("Cannot init object.")
 		return
@@ -146,7 +146,7 @@ func TestDownloadFromYT_WithItag(t *testing.T) {
 }
 
 func TestDownloadFromYT_WhenPlayabilityStatusIsNotOK(t *testing.T) {
-	y := NewYoutube(false)
+	y := NewYoutube(false, false)
 	if y == nil {
 		t.Error("Cannot init object.")
 		return

--- a/example_test.go
+++ b/example_test.go
@@ -16,7 +16,7 @@ func ExampleNewYoutube() {
 	usr, _ := user.Current()
 	currentDir := fmt.Sprintf("%v/Movies/youtubedr", usr.HomeDir)
 	log.Println("download to dir=", currentDir)
-	y := youtube.NewYoutube(true)
+	y := youtube.NewYoutube(true, false)
 	arg := flag.Arg(0)
 	if err := y.DecodeURL(arg); err != nil {
 		fmt.Println("err:", err)

--- a/itag_test.go
+++ b/itag_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestYoutube_GetItagInfo(t *testing.T) {
-	y := NewYoutube(false)
+	y := NewYoutube(false, false)
 	if y == nil {
 		t.Error("Cannot init object.")
 		return

--- a/youtube.go
+++ b/youtube.go
@@ -2,6 +2,7 @@ package youtube
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -45,15 +46,18 @@ type Youtube struct {
 	downloadLevel     float64
 	Title             string
 	Author            string
+
+	// Disable SSL certificate verification
+	InsecureSkipVerify bool
 }
 
 //NewYoutube :Initialize youtube package object.
-func NewYoutube(debug bool) *Youtube {
-	return &Youtube{DebugMode: debug, DownloadPercent: make(chan int64, 100)}
+func NewYoutube(debug bool, insecureSkipVerify bool) *Youtube {
+	return &Youtube{DebugMode: debug, DownloadPercent: make(chan int64, 100), InsecureSkipVerify: insecureSkipVerify}
 }
 
-func NewYoutubeWithSocks5Proxy(debug bool, socks5Proxy string) *Youtube {
-	return &Youtube{DebugMode: debug, DownloadPercent: make(chan int64, 100), Socks5Proxy: socks5Proxy}
+func NewYoutubeWithSocks5Proxy(debug bool, socks5Proxy string, insecureSkipVerify bool) *Youtube {
+	return &Youtube{DebugMode: debug, DownloadPercent: make(chan int64, 100), Socks5Proxy: socks5Proxy, InsecureSkipVerify: insecureSkipVerify}
 }
 
 //DecodeURL : Decode youtube URL to retrieval video information.
@@ -380,6 +384,9 @@ func (y *Youtube) getHTTPClient() (*http.Client, error) {
 		IdleConnTimeout:       60 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+	}
+	if y.InsecureSkipVerify {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint
 	}
 	httpClient := &http.Client{Transport: httpTransport}
 

--- a/youtube_test.go
+++ b/youtube_test.go
@@ -51,7 +51,7 @@ func TestDownload(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			y := NewYoutube(false)
+			y := NewYoutube(false, false)
 			if y == nil {
 				t.Error("Cannot init object.")
 				return
@@ -66,7 +66,7 @@ func TestDownload(t *testing.T) {
 }
 
 func TestDownloadError(t *testing.T) {
-	y := NewYoutube(false)
+	y := NewYoutube(false, false)
 	if y == nil {
 		t.Error("Cannot init object.")
 		return
@@ -86,7 +86,7 @@ func TestDownloadError(t *testing.T) {
 }
 
 func TestParseVideo(t *testing.T) {
-	y := NewYoutube(false)
+	y := NewYoutube(false, false)
 	if y == nil {
 		t.Error("Cannot init object.")
 		return
@@ -260,7 +260,7 @@ func TestYoutube_findVideoID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			y := NewYoutube(false)
+			y := NewYoutube(false, false)
 			if err := y.findVideoID(tt.args.url); (err != nil) != tt.wantErr || err != tt.expectedErr {
 				t.Errorf("findVideoID() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -290,7 +290,7 @@ func TestYoutube_StartDownloadWithHighQuality(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			y := NewYoutube(false)
+			y := NewYoutube(false, false)
 
 			if err := y.StartDownloadWithHighQuality("", "", "hd1080"); (err != nil) != tt.wantErr && !strings.Contains(err.Error(), tt.message) {
 				t.Errorf("StartDownloadWithHighQuality() error = %v, wantErr %v", err, tt.wantErr)
@@ -333,7 +333,7 @@ func TestYoutube_getStreamUrl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			y := NewYoutube(false)
+			y := NewYoutube(false, false)
 			got, err := y.getStreamUrl(tt.args.stream)
 			if err != tt.wantErr {
 				t.Errorf("getStreamUrl() error = %v, wantErr %v", err, tt.wantErr)

--- a/youtubedr/main.go
+++ b/youtubedr/main.go
@@ -18,12 +18,13 @@ Example: youtubedr -o "Campaign Diary".mp4 https://www.youtube.com/watch\?v\=XbN
 `
 
 var (
-	outputFile    string
-	outputDir     string
-	outputQuality string
-	socks5Proxy   string
-	itag          int
-	info          bool
+	outputFile         string
+	outputDir          string
+	outputQuality      string
+	socks5Proxy        string
+	itag               int
+	info               bool
+	insecureSkipVerify bool
 )
 
 func main() {
@@ -47,6 +48,7 @@ func run() error {
 	flag.StringVar(&socks5Proxy, "p", "", "The Socks 5 proxy, e.g. 10.10.10.10:7878")
 	flag.IntVar(&itag, "i", 0, "Specify itag number, e.g. 13, 17")
 	flag.BoolVar(&info, "info", false, "show info of video")
+	flag.BoolVar(&insecureSkipVerify, "insecure-skip-tls-verify", false, "skip server certificate verification")
 
 	flag.Parse()
 
@@ -56,9 +58,12 @@ func run() error {
 	}
 
 	log.Println("download to dir=", outputDir)
-	y := youtube.NewYoutubeWithSocks5Proxy(true, socks5Proxy)
+	y := youtube.NewYoutubeWithSocks5Proxy(true, socks5Proxy, insecureSkipVerify)
 	if len(y.Socks5Proxy) == 0 {
 		log.Println("Using http without proxy.")
+	}
+	if y.InsecureSkipVerify {
+		log.Println("Skip server certificate verification")
 	}
 	arg := flag.Arg(0)
 	if err := y.DecodeURL(arg); err != nil {


### PR DESCRIPTION
# Description

to add --insecure-skip-verify option to skip server certificate verification.

## Issues to fix

Please link issues this PR will fix: \
https://github.com/kkdai/youtube/issues/80

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
