### PR TITLE
HLS and DASH manifests for livestreams

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,7 @@ var (
 )
 
 const dwlURL string = "https://www.youtube.com/watch?v=rFejpH_tAHM"
+const streamURL string = "https://www.youtube.com/watch?v=5qap5aO4i9A"
 const errURL string = "https://www.youtube.com/watch?v=I8oGsuQ"
 
 func TestParseVideo(t *testing.T) {
@@ -73,4 +74,12 @@ func TestYoutube_findVideoID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetVideo(t *testing.T) {
+	video, err := testClient.GetVideo(streamURL)
+	assert.NoError(t, err)
+	assert.NotNil(t, video)
+	assert.NotEmpty(t, video.HLSManifestURL)
+	assert.NotEmpty(t, video.DASHManifestURL)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,104 +1,87 @@
 package youtube
 
 import (
-	"context"
+	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestDownload_Regular(t *testing.T) {
-	ctx := context.Background()
+var (
+	testClient = Client{Debug: true}
+)
 
-	testcases := []struct {
-		name       string
-		url        string
-		outputFile string
-		itagNo     int
-		quality    string
+const dwlURL string = "https://www.youtube.com/watch?v=rFejpH_tAHM"
+const streamURL string = "https://www.youtube.com/watch?v=5qap5aO4i9A"
+const errURL string = "https://www.youtube.com/watch?v=I8oGsuQ"
+
+func TestParseVideo(t *testing.T) {
+
+	video, err := testClient.GetVideo(dwlURL)
+	assert.NoError(t, err)
+	assert.NotNil(t, video)
+
+	_, err = testClient.GetVideo(errURL)
+	assert.EqualError(t, err, `response status: 'fail', reason: 'Invalid parameters.'`)
+}
+
+func TestYoutube_findVideoID(t *testing.T) {
+	type args struct {
+		url string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		expectedErr error
 	}{
 		{
-			// Video from issue #25
-			name:       "default",
-			url:        "https://www.youtube.com/watch?v=54e6lBE3BoQ",
-			outputFile: "default_test.mp4",
-			quality:    "",
+			name: "valid url",
+			args: args{
+				dwlURL,
+			},
+			wantErr:     false,
+			expectedErr: nil,
 		},
 		{
-			// Video from issue #25
-			name:       "quality:medium",
-			url:        "https://www.youtube.com/watch?v=54e6lBE3BoQ",
-			outputFile: "medium_test.mp4",
-			quality:    "medium",
+			name: "valid id",
+			args: args{
+				"rFejpH_tAHM",
+			},
+			wantErr:     false,
+			expectedErr: nil,
 		},
 		{
-			name: "without-filename",
-			url:  "https://www.youtube.com/watch?v=n3kPvBCYT3E",
+			name: "invalid character in id",
+			args: args{
+				"<M13",
+			},
+			wantErr:     true,
+			expectedErr: ErrInvalidCharactersInVideoID,
 		},
 		{
-			name:       "Format",
-			url:        "https://www.youtube.com/watch?v=54e6lBE3BoQ",
-			outputFile: "muxedstream_test.mp4",
-			itagNo:     18,
-		},
-		{
-			name:       "AdaptiveFormat_video",
-			url:        "https://www.youtube.com/watch?v=54e6lBE3BoQ",
-			outputFile: "adaptiveStream_video_test.m4v",
-			itagNo:     134,
-		},
-		{
-			name:       "AdaptiveFormat_audio",
-			url:        "https://www.youtube.com/watch?v=54e6lBE3BoQ",
-			outputFile: "adaptiveStream_audio_test.m4a",
-			itagNo:     140,
+			name: "video id is less than 10 characters",
+			args: args{
+				"rFejpH",
+			},
+			wantErr:     true,
+			expectedErr: ErrVideoIDMinLength,
 		},
 	}
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			require := require.New(t)
-
-			video, err := testClient.GetVideoContext(ctx, tc.url)
-			require.NoError(err)
-
-			var format *Format
-			if tc.itagNo > 0 {
-				format = video.Formats.FindByItag(tc.itagNo)
-				require.NotNil(format)
-			} else {
-				format = &video.Formats[0]
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := extractVideoID(tt.args.url); (err != nil) != tt.wantErr || err != tt.expectedErr {
+				t.Errorf("extractVideoID() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
-			url, err := testClient.GetStreamURLContext(ctx, video, format)
-			require.NoError(err)
-			require.NotEmpty(url)
 		})
 	}
 }
 
-func TestDownload_WhenPlayabilityStatusIsNotOK(t *testing.T) {
-	testcases := []struct {
-		issue   string
-		videoID string
-		err     string
-	}{
-		{
-			issue:   "issue#65",
-			videoID: "9ja-K2FslBU",
-			err:     `status: ERROR`,
-		},
-		{
-			issue:   "issue#59",
-			videoID: "nINQjT7Zr9w",
-			err:     `status: LOGIN_REQUIRED`,
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.issue, func(t *testing.T) {
-			_, err := testClient.GetVideo(tc.videoID)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.err)
-		})
-	}
+func TestGetVideo(t *testing.T) {
+	require := require.New(t)
+	video, err := testClient.GetVideo(streamURL)
+	require.NoError(err)
+	require.NotNil(video)
+	require.NotEmpty(video.HLSManifestURL)
+	require.NotEmpty(video.DASHManifestURL)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,10 +1,10 @@
 package youtube
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/response_data.go
+++ b/response_data.go
@@ -11,6 +11,8 @@ type playerResponseData struct {
 		ExpiresInSeconds string   `json:"expiresInSeconds"`
 		Formats          []Format `json:"formats"`
 		AdaptiveFormats  []Format `json:"adaptiveFormats"`
+		DashManifestURL  string   `json:"dashManifestUrl"`
+		HlsManifestURL   string   `json:"hlsManifestUrl"`
 	} `json:"streamingData"`
 	Captions struct {
 		PlayerCaptionsRenderer struct {

--- a/video.go
+++ b/video.go
@@ -10,11 +10,13 @@ import (
 )
 
 type Video struct {
-	ID       string
-	Title    string
-	Author   string
-	Duration time.Duration
-	Formats  FormatList
+	ID              string
+	Title           string
+	Author          string
+	Duration        time.Duration
+	Formats         FormatList
+	DASHManifestURL string // URI of the DASH manifest file
+	HLSManifestURL  string // URI of the HLS manifest file
 }
 
 func (v *Video) parseVideoInfo(info string) error {
@@ -63,6 +65,9 @@ func (v *Video) parseVideoInfo(info string) error {
 	if len(v.Formats) == 0 {
 		return errors.New("no formats found in the server's answer")
 	}
+
+	v.HLSManifestURL = prData.StreamingData.HlsManifestURL
+	v.DASHManifestURL = prData.StreamingData.DashManifestURL
 
 	return nil
 }


### PR DESCRIPTION
# Description

Added parsing of HLS and DASH manifest URLs for livestreams. Inspired by functionality of the [rylio/ytdl](https://github.com/rylio/ytdl) package.

Makes the package useful for YouTube livestreams.

## Issues to fix

Introduces the livestreams support as mentioned in \#72, also makes it easier to implement the downloading of livestreams in the future.