### PR TITLE
wrong option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Please check out the [example_test.go](example_test.go) for example code.
 | :----- | :----- | :------------------------------------------------------------- | :--------------------- |
 | `-d`   | string | the output directory                                           | $HOME/Movies/youtubedr |
 | `-o`   | string | the output file name ( ext will auto detect on default value ) | [video's title].ext    |
-| `-d`   | string | the Socks 5 proxy (e.g. 10.10.10.10:7878)                      |                        |
+| `-p`   | string | the Socks 5 proxy (e.g. 10.10.10.10:7878)                      |                        |
 | `-q`   | string | the output file quality (medium, hd720)                        |                        |
 | `-i`   | string | the output file itag (13, 17 etc..)                             | 0                    |
 | `-info`| bool   | show information of available streams (quality, itag, MIMEtype)                        |                        |


### PR DESCRIPTION
#100 Description

there is a duplicate '-d' option, I found you used '-p' option for proxy so changed it in the readme file

## Issues to fix

Please link issues this PR will fix: \
\#_[issue number]_

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
