### PR TITLE
Expose Description in Video struct

### DIFF
--- a/cmd/youtubedr/main.go
+++ b/cmd/youtubedr/main.go
@@ -98,6 +98,7 @@ func run() error {
 
 	if info {
 		fmt.Printf("Title:    %s\n", video.Title)
+		fmt.Printf("Description:    %s\n", video.Description)
 		fmt.Printf("Author:   %s\n", video.Author)
 		fmt.Printf("Duration: %v\n", video.Duration)
 

--- a/video.go
+++ b/video.go
@@ -12,6 +12,7 @@ import (
 type Video struct {
 	ID              string
 	Title           string
+	Description     string
 	Author          string
 	Duration        time.Duration
 	Formats         FormatList
@@ -45,6 +46,7 @@ func (v *Video) parseVideoInfo(info string) error {
 	}
 
 	v.Title = prData.VideoDetails.Title
+	v.Description = prData.VideoDetails.ShortDescription
 	v.Author = prData.VideoDetails.Author
 
 	if seconds, _ := strconv.Atoi(prData.Microformat.PlayerMicroformatRenderer.LengthSeconds); seconds > 0 {


### PR DESCRIPTION
Would be a pitty to have to use the cumbersome v3 API bindings just for
that.

# Description

Expose the video description in the `Video` struct

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
