### PR TITLE
info: add bitrate

### DIFF
--- a/cmd/youtubedr/info.go
+++ b/cmd/youtubedr/info.go
@@ -26,10 +26,15 @@ var infoCmd = &cobra.Command{
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetAutoWrapText(false)
-		table.SetHeader([]string{"itag", "quality", "MimeType"})
+		table.SetHeader([]string{"itag", "quality", "bitrate", "MimeType"})
 
 		for _, itag := range video.Formats {
-			table.Append([]string{strconv.Itoa(itag.ItagNo), itag.Quality, itag.MimeType})
+			table.Append([]string{
+				strconv.Itoa(itag.ItagNo),
+				itag.Quality,
+				strconv.Itoa(itag.Bitrate),
+				itag.MimeType,
+			})
 		}
 		table.Render()
 	},


### PR DESCRIPTION
Currently, the Quality is not enough to differentiate some files. For example
with this link:

https://www.youtube.com/watch?v=wHvgUD5uKPk

Among others you get these:

~~~
+------+---------+--------------------------------------------+
| ITAG | QUALITY |                  MIMETYPE                  |
+------+---------+--------------------------------------------+
|  249 | tiny    | audio/webm; codecs="opus"                  |
|  250 | tiny    | audio/webm; codecs="opus"                  |
|  251 | tiny    | audio/webm; codecs="opus"                  |
+------+---------+--------------------------------------------+
~~~

These appear exactly the same. After this change, will look like this:

~~~
+------+---------+---------+--------------------------------------------+
| ITAG | QUALITY | BITRATE |                  MIMETYPE                  |
+------+---------+---------+--------------------------------------------+
|  249 | tiny    |   56255 | audio/webm; codecs="opus"                  |
|  250 | tiny    |   75972 | audio/webm; codecs="opus"                  |
|  251 | tiny    |  149560 | audio/webm; codecs="opus"                  |
+------+---------+---------+--------------------------------------------+
~~~