### PR TITLE
Print audio quality

### DIFF
--- a/cmd/youtubedr/info.go
+++ b/cmd/youtubedr/info.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ var infoCmd = &cobra.Command{
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetAutoWrapText(false)
-		table.SetHeader([]string{"itag", "quality", "size [MB]", "bitrate", "MimeType"})
+		table.SetHeader([]string{"itag", "video quality", "audio quality", "size [MB]", "bitrate", "MimeType"})
 
 		for _, itag := range video.Formats {
 			bitrate := itag.AverageBitrate
@@ -37,6 +38,7 @@ var infoCmd = &cobra.Command{
 			table.Append([]string{
 				strconv.Itoa(itag.ItagNo),
 				itag.Quality,
+				strings.ToLower(strings.TrimPrefix(itag.AudioQuality, "AUDIO_QUALITY_")),
 				fmt.Sprintf("%0.1f", float64(bitrate)*video.Duration.Seconds()/8/1024/1024),
 				strconv.Itoa(bitrate),
 				itag.MimeType,


### PR DESCRIPTION
@prajaraksh what do you think about this output?
```
go run . info rFejpH_tAHM

+------+---------------+---------------+-----------+---------+--------------------------------------------+
| ITAG | VIDEO QUALITY | AUDIO QUALITY | SIZE [MB] | BITRATE |                  MIMETYPE                  |
+------+---------------+---------------+-----------+---------+--------------------------------------------+
|   18 | medium        | low           |      62.6 |  377450 | video/mp4; codecs="avc1.42001E, mp4a.40.2" |
|   22 | hd720         | medium        |     122.4 |  737483 | video/mp4; codecs="avc1.64001F, mp4a.40.2" |
|  137 | hd1080        |               |     202.1 | 1217823 | video/mp4; codecs="avc1.640028"            |
|  248 | hd1080        |               |     279.2 | 1682769 | video/webm; codecs="vp9"                   |
|  136 | hd720         |               |     101.4 |  610810 | video/mp4; codecs="avc1.4d401f"            |
|  247 | hd720         |               |     137.8 |  830520 | video/webm; codecs="vp9"                   |
|  135 | large         |               |      51.0 |  307588 | video/mp4; codecs="avc1.4d401e"            |
|  244 | large         |               |      62.9 |  378782 | video/webm; codecs="vp9"                   |
|  134 | medium        |               |      24.5 |  147436 | video/mp4; codecs="avc1.4d401e"            |
|  243 | medium        |               |      37.5 |  225939 | video/webm; codecs="vp9"                   |
|  133 | small         |               |       8.9 |   53812 | video/mp4; codecs="avc1.4d4015"            |
|  242 | small         |               |      18.9 |  113676 | video/webm; codecs="vp9"                   |
|  160 | tiny          |               |       4.7 |   28398 | video/mp4; codecs="avc1.4d400c"            |
|  278 | tiny          |               |      12.1 |   73188 | video/webm; codecs="vp9"                   |
|  140 | tiny          | medium        |      21.1 |  127063 | audio/mp4; codecs="mp4a.40.2"              |
|  249 | tiny          | low           |       8.4 |   50653 | audio/webm; codecs="opus"                  |
|  250 | tiny          | low           |       9.6 |   57776 | audio/webm; codecs="opus"                  |
|  251 | tiny          | medium        |      17.5 |  105629 | audio/webm; codecs="opus"                  |
+------+---------------+---------------+-----------+---------+--------------------------------------------+
```
