### PR TITLE
add multiple args for info & download, add output format for info

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,8 +11,11 @@ import (
 
 // Client offers methods to download video metadata and video streams.
 type Client struct {
+	// TODO implement loglevel instead
 	// Debug enables debugging output through log package
 	Debug bool
+	// DebugHTTPClient enables debugging output through log package
+	DebugHTTPClient bool
 
 	// HTTPClient can be used to set a custom HTTP client.
 	// If not set, http.DefaultClient will be used
@@ -137,7 +140,7 @@ func (c *Client) httpGet(ctx context.Context, url string) (resp *http.Response, 
 		client = http.DefaultClient
 	}
 
-	if c.Debug {
+	if c.DebugHTTPClient {
 		log.Println("GET", url)
 	}
 

--- a/cmd/youtubedr/downloader.go
+++ b/cmd/youtubedr/downloader.go
@@ -16,13 +16,18 @@ import (
 )
 
 var (
-	insecureSkipVerify bool   // skip TLS server validation
-	outputQuality      string // itag number or quality string
+	insecureSkipVerify bool     // skip TLS server validation
+	outputQuality      string   // itag number or quality string
+	codec              []string // codec
 	downloader         *ytdl.Downloader
 )
 
 func addQualityFlag(flagSet *pflag.FlagSet) {
 	flagSet.StringVarP(&outputQuality, "quality", "q", "", "The itag number or quality label (hd720, medium)")
+}
+
+func addCodecFlag(flagSet *pflag.FlagSet) {
+	flagSet.StringArrayVarP(&codec, "codec", "c", []string{}, "Codec to filter (mp4, webm, av01, avc1) - when multiple terms are given, all terms must be present in mime-type")
 }
 
 func getDownloader() *ytdl.Downloader {
@@ -65,6 +70,9 @@ func getVideoWithFormat(id string) (*youtube.Video, *youtube.Format, error) {
 		return nil, nil, err
 	}
 
+	if len(codec) > 0 {
+		filterCodecs(video, codec)
+	}
 	if len(video.Formats) == 0 {
 		return nil, nil, errors.New("no formats found")
 	}

--- a/cmd/youtubedr/info.go
+++ b/cmd/youtubedr/info.go
@@ -1,60 +1,138 @@
 package main
 
 import (
+	"encoding/csv"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/kkdai/youtube/v2"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
+var infoCmdOpts struct {
+	outputFormat string
+}
+
 // infoCmd represents the info command
 var infoCmd = &cobra.Command{
-	Use:   "info",
-	Short: "Print metadata of the desired video",
-	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		video, err := getDownloader().GetVideo(args[0])
-		exitOnError(err)
-
-		fmt.Println("Title:      ", video.Title)
-		fmt.Println("Author:     ", video.Author)
-		fmt.Println("Duration:   ", video.Duration)
-		fmt.Println("Description:", video.Description)
-		fmt.Println()
-
-		table := tablewriter.NewWriter(os.Stdout)
-		table.SetAutoWrapText(false)
-		table.SetHeader([]string{"itag", "video quality", "audio quality", "size [MB]", "bitrate", "MimeType"})
-
-		for _, format := range video.Formats {
-			bitrate := format.AverageBitrate
-			if bitrate == 0 {
-				// Some formats don't have the average bitrate
-				bitrate = format.Bitrate
-			}
-
-			size, _ := strconv.ParseInt(format.ContentLength, 10, 64)
-			if size == 0 {
-				// Some formats don't have this information
-				size = int64(float64(bitrate) * video.Duration.Seconds() / 8)
-			}
-
-			table.Append([]string{
-				strconv.Itoa(format.ItagNo),
-				format.QualityLabel,
-				strings.ToLower(strings.TrimPrefix(format.AudioQuality, "AUDIO_QUALITY_")),
-				fmt.Sprintf("%0.1f", float64(size)/1024/1024),
-				strconv.Itoa(bitrate),
-				format.MimeType,
-			})
+	Use:          "info",
+	Short:        "Print metadata of the desired videos",
+	Example:      `info https://www.youtube.com/watch\?v\=XbNghLqsVwU https://www.youtube.com/watch\?v\=XbNghLqsVwU`,
+	Args:         cobra.MinimumNArgs(1),
+	SilenceUsage: true,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if !strings.Contains("|full|media|media-csv|", fmt.Sprintf("|%s|", infoCmdOpts.outputFormat)) {
+			return fmt.Errorf("output format %s is not valid", infoCmdOpts.outputFormat)
 		}
-		table.Render()
+		return nil
 	},
+	Run: func(cmd *cobra.Command, args []string) {
+		for _, videoURL := range args {
+			video, err := getDownloader().GetVideo(videoURL)
+			if err != nil {
+				if infoCmdOpts.outputFormat == "media-csv" {
+					fmt.Printf("-2,%s,%s\n", videoURL, err)
+				} else {
+					fmt.Printf("ERROR: %s - %s\n", videoURL, err)
+				}
+				continue
+			}
+			if len(video.Formats) == 0 {
+				if infoCmdOpts.outputFormat == "media-csv" {
+					fmt.Printf("-3,%s,%s\n", videoURL, "no formats found")
+				} else {
+					fmt.Printf("ERROR: %s - %s\n", videoURL, "no formats found")
+				}
+				continue
+			} else if len(codec) > 0 {
+				filterCodecs(video, codec)
+			}
+
+			data := buildFormats(video)
+
+			if infoCmdOpts.outputFormat == "media-csv" {
+				fmt.Printf("0,%s,%s\n", videoURL, video.Title)
+				w := csv.NewWriter(os.Stdout)
+				for _, record := range data {
+					if err := w.Write(record); err != nil {
+						fmt.Printf("-1,%s,%s\n", videoURL, err)
+					}
+				}
+				w.Flush()
+				if err := w.Error(); err != nil {
+					fmt.Printf("-1,%s,%s\n", videoURL, err)
+					continue
+				}
+			}
+
+			if infoCmdOpts.outputFormat == "full" || infoCmdOpts.outputFormat == "media" {
+				fmt.Println("Title:      ", video.Title)
+				if infoCmdOpts.outputFormat == "full" {
+					fmt.Println("Author:     ", video.Author)
+					fmt.Println("Duration:   ", video.Duration)
+					fmt.Println("Description:", video.Description)
+					fmt.Println()
+				}
+				table := tablewriter.NewWriter(os.Stdout)
+				table.SetAutoWrapText(false)
+				table.SetHeader([]string{"itag", "video quality", "audio quality", "size [MB]", "bitrate", "MimeType"})
+				table.AppendBulk(data)
+				table.Render()
+			}
+		}
+	},
+}
+
+// filterCodecs filters out codec with strings.Contains and uses AND operator
+func filterCodecs(video *youtube.Video, codec []string) {
+	var formats youtube.FormatList
+VideoFormat:
+	for _, f := range video.Formats {
+		for _, c := range codec {
+			if !strings.Contains(f.MimeType, c) {
+				continue VideoFormat
+			}
+		}
+		formats = append(formats, f)
+	}
+	video.Formats = formats
+	sort.SliceStable(video.Formats, video.SortBitrateDesc)
+}
+
+func buildFormats(video *youtube.Video) (data [][]string) {
+	for _, format := range video.Formats {
+		bitrate := format.AverageBitrate
+		if bitrate == 0 {
+			// Some formats don't have the average bitrate
+			bitrate = format.Bitrate
+		}
+
+		size, _ := strconv.ParseInt(format.ContentLength, 10, 64)
+		if size == 0 {
+			// Some formats don't have this information
+			size = int64(float64(bitrate) * video.Duration.Seconds() / 8)
+		}
+
+		data = append(data, []string{
+			strconv.Itoa(format.ItagNo),
+			format.QualityLabel,
+			strings.ToLower(strings.TrimPrefix(format.AudioQuality, "AUDIO_QUALITY_")),
+			fmt.Sprintf("%0.1f", float64(size)/1024/1024),
+			strconv.Itoa(bitrate),
+			format.MimeType,
+		})
+	}
+
+	return
 }
 
 func init() {
 	rootCmd.AddCommand(infoCmd)
+
+	infoCmd.Flags().StringVarP(&infoCmdOpts.outputFormat, "output", "o", "full", "full, media, media-csv")
+	addCodecFlag(infoCmd.Flags())
 }

--- a/cmd/youtubedr/root.go
+++ b/cmd/youtubedr/root.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	cfgFile string
-	verbose bool
+	cfgFile           string
+	verbose           bool
+	verboseHTTPClient bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -32,6 +33,8 @@ Use the HTTP_PROXY environment variable to set a HTTP or SOCSK5 proxy. The proxy
 func init() {
 	cobra.OnInitialize(initConfig)
 	cobra.OnInitialize(func() {
+		getDownloader().DebugHTTPClient = verboseHTTPClient
+		getDownloader().Debug = verbose
 		if !verbose {
 			log.SetOutput(ioutil.Discard)
 		}
@@ -43,6 +46,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.youtubedr.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", true, "Enable verbose output")
+	rootCmd.PersistentFlags().BoolVar(&verboseHTTPClient, "log-http", false, "Enable Log HTTP Client")
 	rootCmd.PersistentFlags().BoolVar(&insecureSkipVerify, "insecure", false, "Skip TLS server certificate verification")
 }
 

--- a/cmd/youtubedr/url.go
+++ b/cmd/youtubedr/url.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -10,19 +11,33 @@ import (
 var urlCmd = &cobra.Command{
 	Use:   "url",
 	Short: "Only output the stream-url to desired video",
-	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		video, format, err := getVideoWithFormat(args[0])
-		exitOnError(err)
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var errors []string
+		for _, videoURL := range args {
+			video, format, err := getVideoWithFormat(videoURL)
+			if err != nil {
+				errors = append(errors, err.Error())
+				continue
+			}
 
-		url, err := downloader.GetStreamURL(video, format)
-		exitOnError(err)
+			fmt.Printf("Video '%s' - Quality '%s' - Codec '%s'", video.Title, format.QualityLabel, format.MimeType)
+			url, err := downloader.GetStreamURL(video, format)
+			if err != nil {
+				errors = append(errors, err.Error())
+			}
 
-		fmt.Println(url)
+			fmt.Println(url)
+		}
+		if len(errors) > 0 {
+			return fmt.Errorf(strings.Join(errors, " | "))
+		}
+		return nil
 	},
 }
 
 func init() {
 	addQualityFlag(urlCmd.Flags())
+	addCodecFlag(urlCmd.Flags())
 	rootCmd.AddCommand(urlCmd)
 }

--- a/cmd/youtubedr/version.go
+++ b/cmd/youtubedr/version.go
@@ -9,9 +9,9 @@ import (
 
 var (
 	// set through ldflags
-	version string
-	commit  string
-	date    string
+	version   string
+	commit    string
+	buildTime string
 )
 
 // versionCmd represents the version command
@@ -21,7 +21,7 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Version:    ", version)
 		fmt.Println("Commit:     ", commit)
-		fmt.Println("Date:       ", date)
+		fmt.Println("Date:       ", buildTime)
 		fmt.Println("Go Version: ", runtime.Version())
 	},
 }

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -39,6 +39,7 @@ func (dl *Downloader) getOutputFile(v *youtube.Video, format *youtube.Format, ou
 
 // Download : Starting download video by arguments.
 func (dl *Downloader) Download(ctx context.Context, v *youtube.Video, format *youtube.Format, outputFile string) error {
+	dl.logf("Video '%s' - Quality '%s' - Codec '%s'", v.Title, format.QualityLabel, format.MimeType)
 	destFile, err := dl.getOutputFile(v, format, outputFile)
 	if err != nil {
 		return err
@@ -60,8 +61,20 @@ func (dl *Downloader) DownloadWithHighQuality(ctx context.Context, outputFile st
 	var videoFormat, audioFormat *youtube.Format
 
 	switch quality {
+	case "hdr2060":
+		videoFormat = v.Formats.FindByItag(401)
+		audioFormat = v.Formats.FindByItag(140)
+	case "hdr1080":
+		videoFormat = v.Formats.FindByItag(399)
+		audioFormat = v.Formats.FindByItag(140)
 	case "hd1080":
 		videoFormat = v.Formats.FindByItag(137)
+		audioFormat = v.Formats.FindByItag(140)
+	case "hdr720":
+		videoFormat = v.Formats.FindByItag(398)
+		audioFormat = v.Formats.FindByItag(140)
+	case "hd720":
+		videoFormat = v.Formats.FindByItag(136)
 		audioFormat = v.Formats.FindByItag(140)
 	default:
 		return fmt.Errorf("unknown quality: %s", quality)
@@ -73,6 +86,8 @@ func (dl *Downloader) DownloadWithHighQuality(ctx context.Context, outputFile st
 	if audioFormat == nil {
 		return fmt.Errorf("no format audio/mp4 for %s found", quality)
 	}
+
+	dl.logf("Video '%s' - Quality '%s' - Video Codec '%s' - Audio Codec '%s'", v.Title, videoFormat.QualityLabel, videoFormat.MimeType, audioFormat.MimeType)
 
 	destFile, err := dl.getOutputFile(v, videoFormat, outputFile)
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -108,6 +109,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kkdai/youtube v1.2.4 h1:LyuoTd268oRvd2uqNB6XmQx3HiIdLuLDGZ7oo22hRcI=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -159,9 +161,11 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=

--- a/video.go
+++ b/video.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"time"
 )
@@ -114,9 +115,18 @@ func (v *Video) extractDataFromPlayerResponse(prData playerResponseData) error {
 	if len(v.Formats) == 0 {
 		return errors.New("no formats found in the server's answer")
 	}
+	sort.SliceStable(v.Formats, v.SortBitrateDesc)
 
 	v.HLSManifestURL = prData.StreamingData.HlsManifestURL
 	v.DASHManifestURL = prData.StreamingData.DashManifestURL
 
 	return nil
+}
+
+func (v *Video) SortBitrateDesc(i int, j int) bool {
+	return v.Formats[i].Bitrate > v.Formats[j].Bitrate
+}
+
+func (v *Video) SortBitrateAsc(i int, j int) bool {
+	return v.Formats[i].Bitrate < v.Formats[j].Bitrate
 }


### PR DESCRIPTION
# Description

- Add flag `--codec` to filter out wanted codec in `info` & `download` cmds
- `download` cmd to accept mutlitple urls (outputFile flag is removed)
- `info` also accepts multiple urls
- `info` has a new flag `output` which accepts `full`, `media`, `media-csv` as output format
- add flag `--log-http` to distinguish with `verbose` as noted in comment, `--log-level` is should be a better approche 

## Issues to fix

Please link issues this PR will fix: \
\#_[issue number]_

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

- [x] run "make build" to build the code
- [x] run "make format" to reformat the code
- [x] run "make lint" if you are using unix system
- [x] run "make test-integration" to pass all tests 
