### PR TITLE
Add decipher operations cache

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,9 @@ type Client struct {
 	// HTTPClient can be used to set a custom HTTP client.
 	// If not set, http.DefaultClient will be used
 	HTTPClient *http.Client
+
+	// decipherOpsCache cache decipher operations
+	decipherOpsCache DecipherOperationsCache
 }
 
 // GetVideo fetches video metadata

--- a/decipher.go
+++ b/decipher.go
@@ -83,7 +83,7 @@ var (
 	swapRegexp    = regexp.MustCompile(fmt.Sprintf("(?m)(?:^|,)(%s)%s", jsvarStr, swapStr))
 )
 
-func (c *Client) parseDecipherOps(ctx context.Context, videoID string) (operations []operation, err error) {
+func (c *Client) parseDecipherOps(ctx context.Context, videoID string) (operations []DecipherOperation, err error) {
 	embedURL := fmt.Sprintf("https://youtube.com/embed/%s?hl=en", videoID)
 	embedBody, err := c.httpGetBodyBytes(ctx, embedURL)
 	if err != nil {
@@ -129,7 +129,7 @@ func (c *Client) parseDecipherOps(ctx context.Context, videoID string) (operatio
 		return nil, err
 	}
 
-	var ops []operation
+	var ops []DecipherOperation
 	for _, s := range regex.FindAllSubmatch(funcBody, -1) {
 		switch string(s[1]) {
 		case reverseKey:
@@ -145,7 +145,7 @@ func (c *Client) parseDecipherOps(ctx context.Context, videoID string) (operatio
 	return ops, nil
 }
 
-func (c *Client) parseDecipherOpsWithCache(ctx context.Context, videoID string) (operations []operation, err error) {
+func (c *Client) parseDecipherOpsWithCache(ctx context.Context, videoID string) (operations []DecipherOperation, err error) {
 	if c.decipherOpsCache == nil {
 		c.decipherOpsCache = NewSimpleCache()
 	}

--- a/decipher.go
+++ b/decipher.go
@@ -37,7 +37,7 @@ func (c *Client) decipherURL(ctx context.Context, videoID string, cipher string)
 		return a.join("")
 	*/
 
-	operations, err := c.parseDecipherOps(ctx, videoID)
+	operations, err := c.parseDecipherOpsWithCache(ctx, videoID)
 	if err != nil {
 		return "", err
 	}
@@ -143,4 +143,22 @@ func (c *Client) parseDecipherOps(ctx context.Context, videoID string) (operatio
 		}
 	}
 	return ops, nil
+}
+
+func (c *Client) parseDecipherOpsWithCache(ctx context.Context, videoID string) (operations []operation, err error) {
+	if c.decipherOpsCache == nil {
+		c.decipherOpsCache = NewSimpleCache()
+	}
+
+	if ops := c.decipherOpsCache.Get(videoID); ops != nil {
+		return ops, nil
+	}
+
+	ops, err := c.parseDecipherOps(ctx, videoID)
+	if err != nil {
+		return nil, err
+	}
+
+	c.decipherOpsCache.Set(videoID, ops)
+	return ops, err
 }

--- a/decipher_operations.go
+++ b/decipher_operations.go
@@ -1,14 +1,14 @@
 package youtube
 
-type operation func([]byte) []byte
+type DecipherOperation func([]byte) []byte
 
-func newSpliceFunc(pos int) operation {
+func newSpliceFunc(pos int) DecipherOperation {
 	return func(bs []byte) []byte {
 		return bs[pos:]
 	}
 }
 
-func newSwapFunc(arg int) operation {
+func newSwapFunc(arg int) DecipherOperation {
 	return func(bs []byte) []byte {
 		pos := arg % len(bs)
 		bs[0], bs[pos] = bs[pos], bs[0]

--- a/decipher_operations_cache.go
+++ b/decipher_operations_cache.go
@@ -9,14 +9,14 @@ var (
 const defaultCacheExpiration = time.Minute * time.Duration(5)
 
 type DecipherOperationsCache interface {
-	Get(videoID string) []operation
-	Set(video string, operations []operation)
+	Get(videoID string) []DecipherOperation
+	Set(video string, operations []DecipherOperation)
 }
 
 type SimpleCache struct {
 	videoID    string
 	expiredAt  time.Time
-	operations []operation
+	operations []DecipherOperation
 }
 
 func NewSimpleCache() *SimpleCache {
@@ -24,14 +24,14 @@ func NewSimpleCache() *SimpleCache {
 }
 
 // Get : get cache  when it has same video id and not expired
-func (s SimpleCache) Get(videoID string) []operation {
+func (s SimpleCache) Get(videoID string) []DecipherOperation {
 	return s.GetCacheBefore(videoID, time.Now())
 }
 
 // GetCacheBefore : can pass time for testing
-func (s SimpleCache) GetCacheBefore(videoID string, time time.Time) []operation {
+func (s SimpleCache) GetCacheBefore(videoID string, time time.Time) []DecipherOperation {
 	if videoID == s.videoID && s.expiredAt.After(time) {
-		operations := make([]operation, len(s.operations))
+		operations := make([]DecipherOperation, len(s.operations))
 		copy(operations, s.operations)
 		return operations
 	}
@@ -39,13 +39,13 @@ func (s SimpleCache) GetCacheBefore(videoID string, time time.Time) []operation 
 }
 
 // Set : set cache with default expiration
-func (s *SimpleCache) Set(videoID string, operations []operation) {
+func (s *SimpleCache) Set(videoID string, operations []DecipherOperation) {
 	s.setWithExpiredTime(videoID, operations, time.Now().Add(defaultCacheExpiration))
 }
 
-func (s *SimpleCache) setWithExpiredTime(videoID string, operations []operation, time time.Time) {
+func (s *SimpleCache) setWithExpiredTime(videoID string, operations []DecipherOperation, time time.Time) {
 	s.videoID = videoID
-	s.operations = make([]operation, len(operations))
+	s.operations = make([]DecipherOperation, len(operations))
 	copy(s.operations, operations)
 	s.expiredAt = time
 }

--- a/decipher_operations_cache.go
+++ b/decipher_operations_cache.go
@@ -9,7 +9,7 @@ var (
 const defaultCacheExpiration = time.Minute * time.Duration(5)
 
 type DecipherOperationsCache interface {
-	Get(videoId string) []operation
+	Get(videoID string) []operation
 	Set(video string, operations []operation)
 }
 
@@ -24,13 +24,13 @@ func NewSimpleCache() *SimpleCache {
 }
 
 // Get : get cache  when it has same video id and not expired
-func (s SimpleCache) Get(videoId string) []operation {
-	return s.GetCacheBefore(videoId, time.Now())
+func (s SimpleCache) Get(videoID string) []operation {
+	return s.GetCacheBefore(videoID, time.Now())
 }
 
 // GetCacheBefore : can pass time for testing
-func (s SimpleCache) GetCacheBefore(videoId string, time time.Time) []operation {
-	if videoId == s.videoID && s.expiredAt.After(time) {
+func (s SimpleCache) GetCacheBefore(videoID string, time time.Time) []operation {
+	if videoID == s.videoID && s.expiredAt.After(time) {
 		operations := make([]operation, len(s.operations))
 		copy(operations, s.operations)
 		return operations
@@ -39,12 +39,12 @@ func (s SimpleCache) GetCacheBefore(videoId string, time time.Time) []operation 
 }
 
 // Set : set cache with default expiration
-func (s *SimpleCache) Set(videoId string, operations []operation) {
-	s.setWithExpiredTime(videoId, operations, time.Now().Add(defaultCacheExpiration))
+func (s *SimpleCache) Set(videoID string, operations []operation) {
+	s.setWithExpiredTime(videoID, operations, time.Now().Add(defaultCacheExpiration))
 }
 
-func (s *SimpleCache) setWithExpiredTime(videoId string, operations []operation, time time.Time) {
-	s.videoID = videoId
+func (s *SimpleCache) setWithExpiredTime(videoID string, operations []operation, time time.Time) {
+	s.videoID = videoID
 	s.operations = make([]operation, len(operations))
 	copy(s.operations, operations)
 	s.expiredAt = time

--- a/decipher_operations_cache.go
+++ b/decipher_operations_cache.go
@@ -6,6 +6,8 @@ var (
 	_ DecipherOperationsCache = NewSimpleCache()
 )
 
+const defaultCacheExpiration = time.Minute * time.Duration(5)
+
 type DecipherOperationsCache interface {
 	Get(videoId string) []operation
 	Set(video string, operations []operation)
@@ -15,12 +17,10 @@ type SimpleCache struct {
 	videoID    string
 	expiredAt  time.Time
 	operations []operation
-	expiration time.Duration
 }
 
 func NewSimpleCache() *SimpleCache {
-	minutes := time.Minute * time.Duration(1)
-	return &SimpleCache{expiration: minutes}
+	return &SimpleCache{}
 }
 
 // Get : get cache  when it has same video id and not expired
@@ -40,8 +40,12 @@ func (s SimpleCache) GetCacheBefore(videoId string, time time.Time) []operation 
 
 // Set : set cache with default expiration
 func (s *SimpleCache) Set(videoId string, operations []operation) {
+	s.setWithExpiredTime(videoId, operations, time.Now().Add(defaultCacheExpiration))
+}
+
+func (s *SimpleCache) setWithExpiredTime(videoId string, operations []operation, time time.Time) {
 	s.videoID = videoId
-	s.operations = make([]operation, len(s.operations))
+	s.operations = make([]operation, len(operations))
 	copy(s.operations, operations)
-	s.expiredAt = time.Now().Add(s.expiration)
+	s.expiredAt = time
 }

--- a/decipher_operations_cache.go
+++ b/decipher_operations_cache.go
@@ -1,0 +1,47 @@
+package youtube
+
+import "time"
+
+var (
+	_ DecipherOperationsCache = NewSimpleCache()
+)
+
+type DecipherOperationsCache interface {
+	Get(videoId string) []operation
+	Set(video string, operations []operation)
+}
+
+type SimpleCache struct {
+	videoID    string
+	expiredAt  time.Time
+	operations []operation
+	expiration time.Duration
+}
+
+func NewSimpleCache() *SimpleCache {
+	minutes := time.Minute * time.Duration(1)
+	return &SimpleCache{expiration: minutes}
+}
+
+// Get : get cache  when it has same video id and not expired
+func (s SimpleCache) Get(videoId string) []operation {
+	return s.GetCacheBefore(videoId, time.Now())
+}
+
+// GetCacheBefore : can pass time for testing
+func (s SimpleCache) GetCacheBefore(videoId string, time time.Time) []operation {
+	if videoId == s.videoID && s.expiredAt.After(time) {
+		operations := make([]operation, len(s.operations))
+		copy(operations, s.operations)
+		return operations
+	}
+	return nil
+}
+
+// Set : set cache with default expiration
+func (s *SimpleCache) Set(videoId string, operations []operation) {
+	s.videoID = videoId
+	s.operations = make([]operation, len(s.operations))
+	copy(s.operations, operations)
+	s.expiredAt = time.Now().Add(s.expiration)
+}

--- a/decipher_operations_cache_test.go
+++ b/decipher_operations_cache_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestSimpleCache(t *testing.T) {
 	type args struct {
-		setVideoId string
-		getVideoId string
+		setVideoID string
+		getVideoID string
 		operations []operation
 		expiredAt  string
 		getCacheAt string
@@ -21,8 +21,8 @@ func TestSimpleCache(t *testing.T) {
 		{
 			name: "Get cache data with video id",
 			args: args{
-				setVideoId: "test",
-				getVideoId: "test",
+				setVideoID: "test",
+				getVideoID: "test",
 				operations: []operation{func(bytes []byte) []byte { return nil }},
 				expiredAt:  "2021-01-01 00:01:00",
 				getCacheAt: "2021-01-01 00:00:00",
@@ -32,8 +32,8 @@ func TestSimpleCache(t *testing.T) {
 		{
 			name: "Get nil when cache is expired",
 			args: args{
-				setVideoId: "test",
-				getVideoId: "test",
+				setVideoID: "test",
+				getVideoID: "test",
 				operations: []operation{func(bytes []byte) []byte { return nil }},
 				expiredAt:  "2021-01-01 00:00:00",
 				getCacheAt: "2021-01-01 00:00:00",
@@ -43,8 +43,8 @@ func TestSimpleCache(t *testing.T) {
 		{
 			name: "Get nil when video id is not cached",
 			args: args{
-				setVideoId: "test",
-				getVideoId: "not test",
+				setVideoID: "test",
+				getVideoID: "not test",
 				operations: []operation{func(bytes []byte) []byte { return nil }},
 				expiredAt:  "2021-01-01 00:00:01",
 				getCacheAt: "2021-01-01 00:00:00",
@@ -58,9 +58,9 @@ func TestSimpleCache(t *testing.T) {
 			s := NewSimpleCache()
 			timeFormat := "2006-01-02 15:04:05"
 			expiredAt, _ := time.Parse(timeFormat, tt.args.expiredAt)
-			s.setWithExpiredTime(tt.args.setVideoId, tt.args.operations, expiredAt)
+			s.setWithExpiredTime(tt.args.setVideoID, tt.args.operations, expiredAt)
 			getCacheAt, _ := time.Parse(timeFormat, tt.args.getCacheAt)
-			if got := s.GetCacheBefore(tt.args.getVideoId, getCacheAt); len(got) != len(tt.want) {
+			if got := s.GetCacheBefore(tt.args.getVideoID, getCacheAt); len(got) != len(tt.want) {
 				t.Errorf("GetCacheBefore() = %v, want %v", got, tt.want)
 			}
 		})

--- a/decipher_operations_cache_test.go
+++ b/decipher_operations_cache_test.go
@@ -9,32 +9,32 @@ func TestSimpleCache(t *testing.T) {
 	type args struct {
 		setVideoID string
 		getVideoID string
-		operations []operation
+		operations []DecipherOperation
 		expiredAt  string
 		getCacheAt string
 	}
 	tests := []struct {
 		name string
 		args args
-		want []operation
+		want []DecipherOperation
 	}{
 		{
 			name: "Get cache data with video id",
 			args: args{
 				setVideoID: "test",
 				getVideoID: "test",
-				operations: []operation{func(bytes []byte) []byte { return nil }},
+				operations: []DecipherOperation{func(bytes []byte) []byte { return nil }},
 				expiredAt:  "2021-01-01 00:01:00",
 				getCacheAt: "2021-01-01 00:00:00",
 			},
-			want: []operation{func(bytes []byte) []byte { return nil }},
+			want: []DecipherOperation{func(bytes []byte) []byte { return nil }},
 		},
 		{
 			name: "Get nil when cache is expired",
 			args: args{
 				setVideoID: "test",
 				getVideoID: "test",
-				operations: []operation{func(bytes []byte) []byte { return nil }},
+				operations: []DecipherOperation{func(bytes []byte) []byte { return nil }},
 				expiredAt:  "2021-01-01 00:00:00",
 				getCacheAt: "2021-01-01 00:00:00",
 			},
@@ -45,7 +45,7 @@ func TestSimpleCache(t *testing.T) {
 			args: args{
 				setVideoID: "test",
 				getVideoID: "not test",
-				operations: []operation{func(bytes []byte) []byte { return nil }},
+				operations: []DecipherOperation{func(bytes []byte) []byte { return nil }},
 				expiredAt:  "2021-01-01 00:00:01",
 				getCacheAt: "2021-01-01 00:00:00",
 			},

--- a/decipher_operations_cache_test.go
+++ b/decipher_operations_cache_test.go
@@ -1,0 +1,68 @@
+package youtube
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSimpleCache(t *testing.T) {
+	type args struct {
+		setVideoId string
+		getVideoId string
+		operations []operation
+		expiredAt  string
+		getCacheAt string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []operation
+	}{
+		{
+			name: "Get cache data with video id",
+			args: args{
+				setVideoId: "test",
+				getVideoId: "test",
+				operations: []operation{func(bytes []byte) []byte { return nil }},
+				expiredAt:  "2021-01-01 00:01:00",
+				getCacheAt: "2021-01-01 00:00:00",
+			},
+			want: []operation{func(bytes []byte) []byte { return nil }},
+		},
+		{
+			name: "Get nil when cache is expired",
+			args: args{
+				setVideoId: "test",
+				getVideoId: "test",
+				operations: []operation{func(bytes []byte) []byte { return nil }},
+				expiredAt:  "2021-01-01 00:00:00",
+				getCacheAt: "2021-01-01 00:00:00",
+			},
+			want: nil,
+		},
+		{
+			name: "Get nil when video id is not cached",
+			args: args{
+				setVideoId: "test",
+				getVideoId: "not test",
+				operations: []operation{func(bytes []byte) []byte { return nil }},
+				expiredAt:  "2021-01-01 00:00:01",
+				getCacheAt: "2021-01-01 00:00:00",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSimpleCache()
+			timeFormat := "2006-01-02 15:04:05"
+			expiredAt, _ := time.Parse(timeFormat, tt.args.expiredAt)
+			s.setWithExpiredTime(tt.args.setVideoId, tt.args.operations, expiredAt)
+			getCacheAt, _ := time.Parse(timeFormat, tt.args.getCacheAt)
+			if got := s.GetCacheBefore(tt.args.getVideoId, getCacheAt); len(got) != len(tt.want) {
+				t.Errorf("GetCacheBefore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

add simple cache for decipher functions of single video id to avoid repeated http requests
the cache will be cleared when:
-  first call after 5 mins 
-  use deciper for other video id

## Issues to fix

Please link issues this PR will fix: \
\#140
