### PR TITLE
Parse video page if embedding the video on other sites has been disabled

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ func (c *Client) GetVideoContext(ctx context.Context, url string) (*Video, error
 		ID: id,
 	}
 
-	err = v.parseVideoInfo(string(body))
+	err = v.parseVideoInfo(body)
 
 	// If the uploader has disabled embedding the video on other sites, parse video page
 	if err == ErrNotPlayableInEmbed {

--- a/client.go
+++ b/client.go
@@ -44,7 +44,19 @@ func (c *Client) GetVideoContext(ctx context.Context, url string) (*Video, error
 		ID: id,
 	}
 
-	return v, v.parseVideoInfo(string(body))
+	err = v.parseVideoInfo(string(body))
+
+	// If the uploader has disabled embedding the video on other sites, parse video page
+	if err == ErrNotPlayableInEmbed {
+		html, err := c.httpGetBodyBytes(ctx, "https://www.youtube.com/watch?v="+id)
+		if err != nil {
+			return nil, err
+		}
+
+		return v, v.parseVideoPage(html)
+	}
+
+	return v, err
 }
 
 // GetStream returns the HTTP response for a specific format

--- a/errors.go
+++ b/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrInvalidCharactersInVideoID = errors.New("invalid characters in video id")
 	ErrVideoIDMinLength           = errors.New("the video id must be at least 10 characters long")
 	ErrReadOnClosedResBody        = errors.New("http: read on closed response body")
+	ErrNotPlayableInEmbed         = errors.New("embedding of this video has been disabled")
 )
 
 type ErrResponseStatus struct {

--- a/video.go
+++ b/video.go
@@ -58,11 +58,11 @@ func (v *Video) parseVideoInfo(info string) error {
 	if prData.PlayabilityStatus.Status != "OK" {
 		if !prData.PlayabilityStatus.PlayableInEmbed {
 			return ErrNotPlayableInEmbed
-		} else {
-			return &ErrPlayabiltyStatus{
-				Status: prData.PlayabilityStatus.Status,
-				Reason: prData.PlayabilityStatus.Reason,
-			}
+		}
+
+		return &ErrPlayabiltyStatus{
+			Status: prData.PlayabilityStatus.Status,
+			Reason: prData.PlayabilityStatus.Reason,
 		}
 	}
 

--- a/video_test.go
+++ b/video_test.go
@@ -53,6 +53,19 @@ func TestDownload_Regular(t *testing.T) {
 			outputFile: "adaptiveStream_audio_test.m4a",
 			itagNo:     140,
 		},
+		{
+			// Video from issue #138
+			name:       "NotPlayableInEmbed",
+			url:        "https://www.youtube.com/watch?v=gr-IqFcNExY",
+			outputFile: "not_playable_in_embed.mp4",
+		},
+		{
+			// Video from issue #138
+			name:       "NotPlayableInEmbed_cipher",
+			url:        "https://www.youtube.com/watch?v=_4UsZ1icOjA",
+			outputFile: "not_playable_in_embed_cipher.m4v",
+			itagNo:     135,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/video_test.go
+++ b/video_test.go
@@ -59,13 +59,6 @@ func TestDownload_Regular(t *testing.T) {
 			url:        "https://www.youtube.com/watch?v=gr-IqFcNExY",
 			outputFile: "not_playable_in_embed.mp4",
 		},
-		{
-			// Video from issue #138
-			name:       "NotPlayableInEmbed_cipher",
-			url:        "https://www.youtube.com/watch?v=_4UsZ1icOjA",
-			outputFile: "not_playable_in_embed_cipher.m4v",
-			itagNo:     135,
-		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

If the uploader has disabled embedding the video on other sites, parse video page. In this case we need to get the JSON for `ytInitialPlayerResponse` (using regex) and unmarshal that into a `playerResponseData` struct.

## Issues to fix

Please link issues this PR will fix: 
#138 




