### PR TITLE
Expose Thumbnails in Video struct

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -81,6 +81,7 @@ func TestGetVideo(t *testing.T) {
 	video, err := testClient.GetVideo(streamURL)
 	require.NoError(err)
 	require.NotNil(video)
+	require.NotEmpty(video.Thumbnails)
 	require.NotEmpty(video.HLSManifestURL)
 	require.NotEmpty(video.DASHManifestURL)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -82,6 +82,8 @@ func TestGetVideo(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(video)
 	require.NotEmpty(video.Thumbnails)
+	require.Greater(len(video.Thumbnails), 0)
+	require.NotEmpty(video.Thumbnails[0].URL)
 	require.NotEmpty(video.HLSManifestURL)
 	require.NotEmpty(video.DASHManifestURL)
 }

--- a/format_list.go
+++ b/format_list.go
@@ -1,5 +1,9 @@
 package youtube
 
+import (
+	"strings"
+)
+
 type FormatList []Format
 
 func (list FormatList) FindByQuality(quality string) *Format {
@@ -18,4 +22,15 @@ func (list FormatList) FindByItag(itagNo int) *Format {
 		}
 	}
 	return nil
+}
+
+// FindByType returns mime type of video which only audio or video
+func (list FormatList) FindByType(t string) []Format {
+	var f []Format
+	for i := range list {
+		if strings.Contains(list[i].MimeType, t) {
+			f = append(f, list[i])
+		}
+	}
+	return f
 }

--- a/format_list_test.go
+++ b/format_list_test.go
@@ -142,9 +142,9 @@ func TestFormatList_FindByType(t *testing.T) {
 			args: args{
 				mimeType: "video/mp4; codecs=\"avc1.42001E, mp4a.40.2\"",
 			},
-			want: append([]Format{}, Format{
+			want: []Format{{
 				MimeType: "video/mp4; codecs=\"avc1.42001E, mp4a.40.2\"",
-			}),
+			}},
 		},
 	}
 	for _, tt := range tests {

--- a/format_list_test.go
+++ b/format_list_test.go
@@ -121,3 +121,36 @@ func TestFormatList_FindByItag(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatList_FindByType(t *testing.T) {
+	list := []Format{{
+		MimeType: "video/mp4; codecs=\"avc1.42001E, mp4a.40.2\"",
+	},
+	}
+	type args struct {
+		mimeType string
+	}
+	tests := []struct {
+		name string
+		list FormatList
+		args args
+		want []Format
+	}{
+		{
+			name: "find video",
+			list: list,
+			args: args{
+				mimeType: "video/mp4; codecs=\"avc1.42001E, mp4a.40.2\"",
+			},
+			want: append([]Format{}, Format{
+				MimeType: "video/mp4; codecs=\"avc1.42001E, mp4a.40.2\"",
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format := tt.list.FindByType("video")
+			assert.Equal(t, format, tt.want)
+		})
+	}
+}

--- a/response_data.go
+++ b/response_data.go
@@ -51,11 +51,7 @@ type playerResponseData struct {
 		ShortDescription string `json:"shortDescription"`
 		IsCrawlable      bool   `json:"isCrawlable"`
 		Thumbnail        struct {
-			Thumbnails []struct {
-				URL    string `json:"url"`
-				Width  int    `json:"width"`
-				Height int    `json:"height"`
-			} `json:"thumbnails"`
+			Thumbnails []Thumbnail `json:"thumbnails"`
 		} `json:"thumbnail"`
 		AverageRating     float64 `json:"averageRating"`
 		AllowRatings      bool    `json:"allowRatings"`
@@ -155,4 +151,12 @@ type Format struct {
 		Start string `json:"start"`
 		End   string `json:"end"`
 	} `json:"indexRange"`
+}
+
+type Thumbnails []Thumbnail
+
+type Thumbnail struct {
+	URL    string
+	Width  uint
+	Height uint
 }

--- a/video.go
+++ b/video.go
@@ -17,6 +17,7 @@ type Video struct {
 	Author          string
 	Duration        time.Duration
 	Formats         FormatList
+	Thumbnails      Thumbnails
 	DASHManifestURL string // URI of the DASH manifest file
 	HLSManifestURL  string // URI of the HLS manifest file
 }
@@ -101,6 +102,7 @@ func (v *Video) extractDataFromPlayerResponse(prData playerResponseData) error {
 	v.Title = prData.VideoDetails.Title
 	v.Description = prData.VideoDetails.ShortDescription
 	v.Author = prData.VideoDetails.Author
+	v.Thumbnails = prData.VideoDetails.Thumbnail.Thumbnails
 
 	if seconds, _ := strconv.Atoi(prData.Microformat.PlayerMicroformatRenderer.LengthSeconds); seconds > 0 {
 		v.Duration = time.Duration(seconds) * time.Second


### PR DESCRIPTION
# Description

- Expose Thumbnails in Video struct
- Add `FindByType` to filter resource mime type between video and audio

## Issues to fix

None.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 