### PR TITLE
add mime-type flag

### DIFF
--- a/cmd/youtubedr/download.go
+++ b/cmd/youtubedr/download.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -43,12 +44,13 @@ func download(id string) error {
 
 	log.Println("download to directory", outputDir)
 
-	if format.AudioChannels == 0 {
+	if strings.HasPrefix(outputQuality, "hd") {
 		if err := checkFFMPEG(); err != nil {
 			return err
 		}
-		return downloader.DownloadSeparatedStreams(context.Background(), outputFile, video, outputQuality, mimetype)
+		return downloader.DownloadComposite(context.Background(), outputFile, video, outputQuality, mimetype)
 	}
+
 	return downloader.Download(context.Background(), video, format, outputFile)
 }
 

--- a/cmd/youtubedr/url.go
+++ b/cmd/youtubedr/url.go
@@ -24,5 +24,6 @@ var urlCmd = &cobra.Command{
 
 func init() {
 	addQualityFlag(urlCmd.Flags())
+	addMimeTypeFlag(urlCmd.Flags())
 	rootCmd.AddCommand(urlCmd)
 }

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -39,6 +39,7 @@ func (dl *Downloader) getOutputFile(v *youtube.Video, format *youtube.Format, ou
 
 // Download : Starting download video by arguments.
 func (dl *Downloader) Download(ctx context.Context, v *youtube.Video, format *youtube.Format, outputFile string) error {
+	dl.logf("Video '%s' - Quality '%s' - Codec '%s'", v.Title, format.QualityLabel, format.MimeType)
 	destFile, err := dl.getOutputFile(v, format, outputFile)
 	if err != nil {
 		return err
@@ -55,34 +56,14 @@ func (dl *Downloader) Download(ctx context.Context, v *youtube.Video, format *yo
 	return dl.videoDLWorker(ctx, out, v, format)
 }
 
-// DownloadWithHighQuality : Starting downloading video with high quality (>720p).
-func (dl *Downloader) DownloadWithHighQuality(ctx context.Context, outputFile string, v *youtube.Video, quality string) error {
-	var videoFormat, audioFormat *youtube.Format
-
-	switch quality {
-	case "hdr2060":
-		videoFormat = v.Formats.FindByItag(401)
-	case "hdr1080":
-		videoFormat = v.Formats.FindByItag(399)
-	case "hd1080":
-		videoFormat = v.Formats.FindByItag(137)
-	case "hdr720":
-		videoFormat = v.Formats.FindByItag(398)
-	case "hd720":
-		videoFormat = v.Formats.FindByItag(136)
-	default:
-		return fmt.Errorf("unknown quality: %s", quality)
+// DownloadSeparatedStreams : Starting downloading video with high quality (>720p).
+func (dl *Downloader) DownloadSeparatedStreams(ctx context.Context, outputFile string, v *youtube.Video, quality string, mimetype string) error {
+	videoFormat, audioFormat, err1 := getVideoAudioFormats(v, quality, mimetype)
+	if err1 != nil {
+		return err1
 	}
 
-	audioFormat = v.Formats.FindByItag(140)
-
-	if videoFormat == nil {
-		return fmt.Errorf("no format video/mp4 for %s found", quality)
-	}
-	if audioFormat == nil {
-		return fmt.Errorf("no format audio/mp4 for %s found", quality)
-	}
-
+	dl.logf("Video '%s' - Quality '%s' - Video Codec '%s' - Audio Codec '%s'", v.Title, videoFormat.QualityLabel, videoFormat.MimeType, audioFormat.MimeType)
 	destFile, err := dl.getOutputFile(v, videoFormat, outputFile)
 	if err != nil {
 		return err
@@ -128,6 +109,40 @@ func (dl *Downloader) DownloadWithHighQuality(ctx context.Context, outputFile st
 	dl.logf("merging video and audio to %s", destFile)
 
 	return ffmpegVersionCmd.Run()
+}
+
+func getVideoAudioFormats(v *youtube.Video, quality string, mimetype string) (*youtube.Format, *youtube.Format, error) {
+	var videoFormat, audioFormat *youtube.Format
+	var videoFormats, audioFormats youtube.FormatList
+
+	// Default mime-type to mp4
+	if mimetype == "" {
+		mimetype = "mp4"
+	}
+	formats := v.Formats.FindByType(mimetype)
+	videoFormats = formats.FindByType("video").FilterByAudioChannels(0)
+	audioFormats = formats.FindByType("audio")
+	if quality != "" {
+		videoFormats = videoFormats.FilterQuality(quality)
+	}
+
+	if len(videoFormats) > 0 {
+		videoFormats.SortFormats()
+		videoFormat = &videoFormats[0]
+	}
+
+	if len(audioFormats) > 0 {
+		audioFormats.SortFormats()
+		audioFormat = &audioFormats[0]
+	}
+
+	if videoFormat == nil {
+		return nil, nil, fmt.Errorf("no video format found after filtering")
+	}
+	if audioFormat == nil {
+		return nil, nil, fmt.Errorf("no audio format found after filtering")
+	}
+	return videoFormat, audioFormat, nil
 }
 
 func (dl *Downloader) videoDLWorker(ctx context.Context, out *os.File, video *youtube.Video, format *youtube.Format) error {

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -56,8 +56,8 @@ func (dl *Downloader) Download(ctx context.Context, v *youtube.Video, format *yo
 	return dl.videoDLWorker(ctx, out, v, format)
 }
 
-// DownloadSeparatedStreams : Starting downloading video with high quality (>720p).
-func (dl *Downloader) DownloadSeparatedStreams(ctx context.Context, outputFile string, v *youtube.Video, quality string, mimetype string) error {
+// DownloadComposite : Downloads audio and video streams separately and merges them via ffmpeg.
+func (dl *Downloader) DownloadComposite(ctx context.Context, outputFile string, v *youtube.Video, quality string, mimetype string) error {
 	videoFormat, audioFormat, err1 := getVideoAudioFormats(v, quality, mimetype)
 	if err1 != nil {
 		return err1

--- a/downloader/downloader_hq_test.go
+++ b/downloader/downloader_hq_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kkdai/youtube/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,5 +17,49 @@ func TestDownload_HighQuality(t *testing.T) {
 	video, err := testDownloader.Client.GetVideoContext(ctx, "BaW_jenozKc")
 	require.NoError(err)
 
-	require.NoError(testDownloader.DownloadWithHighQuality(ctx, "", video, "hd1080"))
+	require.NoError(testDownloader.DownloadSeparatedStreams(ctx, "", video, "hd1080", "mp4"))
+}
+
+func Test_getVideoAudioFormats(t *testing.T) {
+	require := require.New(t)
+
+	v := &youtube.Video{Formats: []youtube.Format{
+		{ItagNo: 22, MimeType: "video/mp4; codecs=\"avc1.64001F, mp4a.40.2\"", Quality: "hd720", Bitrate: 644187, FPS: 30, Width: 1280, Height: 720, LastModified: "1608827694876411", ContentLength: "0", QualityLabel: "720p", ProjectionType: "RECTANGULAR", AverageBitrate: 0, AudioQuality: "AUDIO_QUALITY_MEDIUM", ApproxDurationMs: "3553976", AudioSampleRate: "44100", AudioChannels: 2},
+		{ItagNo: 136, MimeType: "video/mp4; codecs=\"avc1.4d401f\"", Quality: "hd720", Bitrate: 1640619, FPS: 30, Width: 1280, Height: 720, LastModified: "1608827567796013", ContentLength: "228884308", QualityLabel: "720p", ProjectionType: "RECTANGULAR", AverageBitrate: 515229, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 398, MimeType: "video/mp4; codecs=\"av01.0.05M.08\"", Quality: "hd720", Bitrate: 1480681, FPS: 30, Width: 1280, Height: 720, LastModified: "1610817401605660", ContentLength: "284974685", QualityLabel: "720p", ProjectionType: "RECTANGULAR", AverageBitrate: 641491, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 135, MimeType: "video/mp4; codecs=\"avc1.4d401f\"", Quality: "large", Bitrate: 883476, FPS: 30, Width: 854, Height: 480, LastModified: "1608827567791454", ContentLength: "154191496", QualityLabel: "480p", ProjectionType: "RECTANGULAR", AverageBitrate: 347092, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 244, MimeType: "video/webm; codecs=\"vp9\"", Quality: "large", Bitrate: 758804, FPS: 30, Width: 854, Height: 480, LastModified: "1540471378691303", ContentLength: "204421502", QualityLabel: "480p", ProjectionType: "RECTANGULAR", AverageBitrate: 460162, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 397, MimeType: "video/mp4; codecs=\"av01.0.04M.08\"", Quality: "large", Bitrate: 689144, FPS: 30, Width: 854, Height: 480, LastModified: "1610818826299370", ContentLength: "156644042", QualityLabel: "480p", ProjectionType: "RECTANGULAR", AverageBitrate: 352613, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 18, MimeType: "video/mp4; codecs=\"avc1.42001E, mp4a.40.2\"", Quality: "medium", Bitrate: 585374, FPS: 30, Width: 640, Height: 360, LastModified: "1540458716874187", ContentLength: "260045146", QualityLabel: "360p", ProjectionType: "RECTANGULAR", AverageBitrate: 585361, AudioQuality: "AUDIO_QUALITY_LOW", ApproxDurationMs: "3553976", AudioSampleRate: "44100", AudioChannels: 2},
+		{ItagNo: 134, MimeType: "video/mp4; codecs=\"avc1.4d401e\"", Quality: "medium", Bitrate: 562611, FPS: 30, Width: 640, Height: 360, LastModified: "1608827567788287", ContentLength: "107193162", QualityLabel: "360p", ProjectionType: "RECTANGULAR", AverageBitrate: 241297, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 243, MimeType: "video/webm; codecs=\"vp9\"", Quality: "medium", Bitrate: 415910, FPS: 30, Width: 640, Height: 360, LastModified: "1540470494540739", ContentLength: "124725362", QualityLabel: "360p", ProjectionType: "RECTANGULAR", AverageBitrate: 280762, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 396, MimeType: "video/mp4; codecs=\"av01.0.01M.08\"", Quality: "medium", Bitrate: 360497, FPS: 30, Width: 640, Height: 360, LastModified: "1610815679579168", ContentLength: "97717429", QualityLabel: "360p", ProjectionType: "RECTANGULAR", AverageBitrate: 219966, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 133, MimeType: "video/mp4; codecs=\"avc1.4d4015\"", Quality: "small", Bitrate: 275124, FPS: 30, Width: 426, Height: 240, LastModified: "1608827567783949", ContentLength: "58518802", QualityLabel: "240p", ProjectionType: "RECTANGULAR", AverageBitrate: 131728, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 242, MimeType: "video/webm; codecs=\"vp9\"", Quality: "small", Bitrate: 226276, FPS: 30, Width: 426, Height: 240, LastModified: "1540470499854365", ContentLength: "71003227", QualityLabel: "240p", ProjectionType: "RECTANGULAR", AverageBitrate: 159831, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 395, MimeType: "video/mp4; codecs=\"av01.0.00M.08\"", Quality: "small", Bitrate: 174542, FPS: 30, Width: 426, Height: 240, LastModified: "1610814314861797", ContentLength: "53665816", QualityLabel: "240p", ProjectionType: "RECTANGULAR", AverageBitrate: 120804, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 160, MimeType: "video/mp4; codecs=\"avc1.4d400c\"", Quality: "tiny", Bitrate: 112782, FPS: 30, Width: 256, Height: 144, LastModified: "1608827567783792", ContentLength: "34559820", QualityLabel: "144p", ProjectionType: "RECTANGULAR", AverageBitrate: 77795, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 278, MimeType: "video/webm; codecs=\"vp9\"", Quality: "tiny", Bitrate: 110159, FPS: 30, Width: 256, Height: 144, LastModified: "1540470389548275", ContentLength: "40870406", QualityLabel: "144p", ProjectionType: "RECTANGULAR", AverageBitrate: 92001, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 394, MimeType: "video/mp4; codecs=\"av01.0.00M.08\"", Quality: "tiny", Bitrate: 87070, FPS: 30, Width: 256, Height: 144, LastModified: "1610813435452233", ContentLength: "29475328", QualityLabel: "144p", ProjectionType: "RECTANGULAR", AverageBitrate: 66350, AudioQuality: "", ApproxDurationMs: "3553899", AudioSampleRate: "", AudioChannels: 0},
+		{ItagNo: 140, MimeType: "audio/mp4; codecs=\"mp4a.40.2\"", Quality: "tiny", Bitrate: 133909, FPS: 0, Width: 0, Height: 0, LastModified: "1608826185990888", ContentLength: "57518278", QualityLabel: "", ProjectionType: "RECTANGULAR", AverageBitrate: 129473, AudioQuality: "AUDIO_QUALITY_MEDIUM", ApproxDurationMs: "3553976", AudioSampleRate: "44100", AudioChannels: 2},
+		{ItagNo: 251, MimeType: "audio/webm; codecs=\"opus\"", Quality: "tiny", Bitrate: 168872, FPS: 0, Width: 0, Height: 0, LastModified: "1540474785125205", ContentLength: "62202897", QualityLabel: "", ProjectionType: "RECTANGULAR", AverageBitrate: 140020, AudioQuality: "AUDIO_QUALITY_MEDIUM", ApproxDurationMs: "3553941", AudioSampleRate: "48000", AudioChannels: 2},
+		{ItagNo: 250, MimeType: "audio/webm; codecs=\"opus\"", Quality: "tiny", Bitrate: 92040, FPS: 0, Width: 0, Height: 0, LastModified: "1540474783287362", ContentLength: "32290649", QualityLabel: "", ProjectionType: "RECTANGULAR", AverageBitrate: 72686, AudioQuality: "AUDIO_QUALITY_LOW", ApproxDurationMs: "3553941", AudioSampleRate: "48000", AudioChannels: 2},
+		{ItagNo: 249, MimeType: "audio/webm; codecs=\"opus\"", Quality: "tiny", Bitrate: 72862, FPS: 0, Width: 0, Height: 0, LastModified: "1540474783513282", ContentLength: "24839529", QualityLabel: "", ProjectionType: "RECTANGULAR", AverageBitrate: 55914, AudioQuality: "AUDIO_QUALITY_LOW", ApproxDurationMs: "3553941", AudioSampleRate: "48000", AudioChannels: 2},
+	}}
+	{
+		videoFormat, audioFormat, err := getVideoAudioFormats(v, "hd720", "mp4")
+		require.NoError(err)
+		require.NotNil(videoFormat)
+		require.Equal(398, videoFormat.ItagNo)
+		require.NotNil(audioFormat)
+		require.Equal(140, audioFormat.ItagNo)
+	}
+
+	{
+		videoFormat, audioFormat, err := getVideoAudioFormats(v, "large", "webm")
+		require.NoError(err)
+		require.NotNil(videoFormat)
+		require.Equal(244, videoFormat.ItagNo)
+		require.NotNil(audioFormat)
+		require.Equal(251, audioFormat.ItagNo)
+	}
 }

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -55,12 +55,12 @@ func TestYoutube_DownloadWithHighQualityFails(t *testing.T) {
 		{
 			name:    "video format not found",
 			formats: []youtube.Format{{ItagNo: 140}},
-			message: "no format video/mp4 for hd1080 found",
+			message: "no video format found after filtering",
 		},
 		{
 			name:    "audio format not found",
-			formats: []youtube.Format{{ItagNo: 137}},
-			message: "no format audio/mp4 for hd1080 found",
+			formats: []youtube.Format{{ItagNo: 137, Quality: "hd1080", MimeType: "video/mp4", AudioChannels: 0}},
+			message: "no audio format found after filtering",
 		},
 	}
 	for _, tt := range tests {
@@ -69,7 +69,7 @@ func TestYoutube_DownloadWithHighQualityFails(t *testing.T) {
 				Formats: tt.formats,
 			}
 
-			err := testDownloader.DownloadWithHighQuality(context.Background(), "", video, "hd1080")
+			err := testDownloader.DownloadSeparatedStreams(context.Background(), "", video, "hd1080", "")
 			assert.EqualError(t, err, tt.message)
 		})
 	}

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -69,7 +69,7 @@ func TestYoutube_DownloadWithHighQualityFails(t *testing.T) {
 				Formats: tt.formats,
 			}
 
-			err := testDownloader.DownloadSeparatedStreams(context.Background(), "", video, "hd1080", "")
+			err := testDownloader.DownloadComposite(context.Background(), "", video, "hd1080", "")
 			assert.EqualError(t, err, tt.message)
 		})
 	}

--- a/format_list.go
+++ b/format_list.go
@@ -1,6 +1,8 @@
 package youtube
 
 import (
+	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -26,11 +28,104 @@ func (list FormatList) FindByItag(itagNo int) *Format {
 
 // FindByType returns mime type of video which only audio or video
 func (list FormatList) FindByType(t string) FormatList {
-	var f []Format
+	var fl FormatList
 	for i := range list {
 		if strings.Contains(list[i].MimeType, t) {
-			f = append(f, list[i])
+			fl = append(fl, list[i])
 		}
 	}
-	return f
+	return fl
+}
+
+// FilterQuality returns a new FormatList filtered by quality, quality label or itag,
+// but not audio quality
+func (list FormatList) FilterQuality(quality string) FormatList {
+	var fl FormatList
+	for _, f := range list {
+		itag, _ := strconv.Atoi(quality)
+		if itag == f.ItagNo || strings.Contains(f.Quality, quality) || strings.Contains(f.QualityLabel, quality) {
+			fl = append(fl, f)
+		}
+	}
+	return fl
+}
+
+// FilterByAudioChannels returns a new FormatList filtered by the matching AudioChannels
+func (list FormatList) FilterByAudioChannels(n int) FormatList {
+	var fl FormatList
+	for _, f := range list {
+		if f.AudioChannels == n {
+			fl = append(fl, f)
+		}
+	}
+	return fl
+}
+
+func (v *Video) FilterQuality(quality string) {
+	v.Formats = v.Formats.FilterQuality(quality)
+	//v.AudioFormats = v.AudioFormats.FilterQuality(quality)
+	//v.VideoFormats = v.VideoFormats.FilterQuality(quality)
+	v.Formats.SortFormats()
+}
+
+// SortFormats sort all Formats fields
+func (list FormatList) SortFormats() {
+	sort.SliceStable(list, func(i, j int) bool {
+		return sortFormat(i, j, list)
+	})
+}
+
+// sortFormat sorts video by resolution, FPS, codec (av01, vp9, avc1), bitrate
+// sorts audio by codec (mp4, opus), channels, bitrate, sample rate
+func sortFormat(i int, j int, formats FormatList) bool {
+	// Sort by Width
+	if formats[i].Width == formats[j].Width {
+		// Sort by FPS
+		if formats[i].FPS == formats[j].FPS {
+			if formats[i].FPS == 0 && formats[i].AudioChannels > 0 && formats[j].AudioChannels > 0 {
+				// Audio
+				// Sort by codec
+				codec := map[int]int{}
+				for _, index := range []int{i, j} {
+					if strings.Contains(formats[index].MimeType, "mp4") {
+						codec[index] = 1
+					} else if strings.Contains(formats[index].MimeType, "opus") {
+						codec[index] = 2
+					}
+				}
+				if codec[i] == codec[j] {
+					// Sort by Audio Channel
+					if formats[i].AudioChannels == formats[j].AudioChannels {
+						// Sort by Audio Bitrate
+						if formats[i].Bitrate == formats[j].Bitrate {
+							// Sort by Audio Sample Rate
+							return formats[i].AudioSampleRate > formats[j].AudioSampleRate
+						}
+						return formats[i].Bitrate > formats[j].Bitrate
+					}
+					return formats[i].AudioChannels > formats[j].AudioChannels
+				}
+				return codec[i] < codec[j]
+			}
+			// Video
+			// Sort by codec
+			codec := map[int]int{}
+			for _, index := range []int{i, j} {
+				if strings.Contains(formats[index].MimeType, "av01") {
+					codec[index] = 1
+				} else if strings.Contains(formats[index].MimeType, "vp9") {
+					codec[index] = 2
+				} else if strings.Contains(formats[index].MimeType, "avc1") {
+					codec[index] = 3
+				}
+			}
+			if codec[i] == codec[j] {
+				// Sort by Audio Bitrate
+				return formats[i].Bitrate > formats[j].Bitrate
+			}
+			return codec[i] < codec[j]
+		}
+		return formats[i].FPS > formats[j].FPS
+	}
+	return formats[i].Width > formats[j].Width
 }


### PR DESCRIPTION
# Description

- add flag to filter by mime-type along with quality.
- audio stream is sorted by some criteria before choosing the best stream (audio channels, bitrate, etc.)
- ability to download audio stream

## Issues to fix

Please link issues this PR will fix: \
\#_[issue number]_

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
