### PR TITLE
Fix speed issues

### DIFF
--- a/client.go
+++ b/client.go
@@ -145,13 +145,16 @@ func (c *Client) httpGet(ctx context.Context, url string) (resp *http.Response, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Range", "bytes=0-")
 
 	resp, err = client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusPartialContent:
+	default:
 		resp.Body.Close()
 		return nil, ErrUnexpectedStatusCode(resp.StatusCode)
 	}


### PR DESCRIPTION
Normally, if you were to download a media stream in parts, you would use request headers like this:

    Range: 0-100
    Range: 100-200
    Range: 200-

and the server will respond with 206 Partial Content [1]. I was going to use this tactic so we could download parts of media files concurrently, to speed up the process. However I noticed that YouTube disable throttling whenever you use that header, so you can just download the file in one piece like normal, with just this header:

    Range: 0-

Fixes #151

1. https://developer.mozilla.org/docs/Web/HTTP/Status/206