### PR TITLE
(fix) when itag is specified, mime-type filter must not apply

### DIFF
--- a/cmd/youtubedr/downloader.go
+++ b/cmd/youtubedr/downloader.go
@@ -76,35 +76,30 @@ func getVideoWithFormat(id string) (*youtube.Video, *youtube.Format, error) {
 		return nil, nil, err
 	}
 	formats := video.Formats
+	if mimetype != "" {
+		formats = formats.Type(mimetype)
+	}
+	if len(formats) == 0 {
+		return nil, nil, errors.New("no formats found")
+	}
 
 	var format *youtube.Format
 	itag, _ := strconv.Atoi(outputQuality)
 	switch {
 	case itag > 0:
-		format = formats.FindByItag(itag)
+		// When an itag is specified, do not filter format with mime-type
+		format = video.Formats.FindByItag(itag)
 		if format == nil {
 			return nil, nil, fmt.Errorf("unable to find format with itag %d", itag)
 		}
 
 	case outputQuality != "":
-		if mimetype != "" {
-			formats = formats.Type(mimetype)
-		}
-		if len(formats) == 0 {
-			return nil, nil, errors.New("no formats found")
-		}
 		format = formats.FindByQuality(outputQuality)
 		if format == nil {
 			return nil, nil, fmt.Errorf("unable to find format with quality %s", outputQuality)
 		}
 
 	default:
-		if mimetype != "" {
-			formats = formats.Type(mimetype)
-		}
-		if len(formats) == 0 {
-			return nil, nil, errors.New("no formats found")
-		}
 		// select the first format
 		formats.Sort()
 		format = &formats[0]

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -115,12 +115,11 @@ func getVideoAudioFormats(v *youtube.Video, quality string, mimetype string) (*y
 	var videoFormat, audioFormat *youtube.Format
 	var videoFormats, audioFormats youtube.FormatList
 
-	// Default mime-type to mp4
-	if mimetype == "" {
-		mimetype = "mp4"
+	formats := v.Formats
+	if mimetype != "" {
+		formats = formats.Type(mimetype)
 	}
 
-	formats := v.Formats.Type(mimetype)
 	videoFormats = formats.Type("video").AudioChannels(0)
 	audioFormats = formats.Type("audio")
 


### PR DESCRIPTION
# Description

Fix bug introduced in #167.

Mime-type filter must not be applied with itag `?`

## Issues to fix

Please link issues this PR will fix: \
\#181 

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
