### PR TITLE
Format: use int64 for ContentLength

### DIFF
--- a/cmd/youtubedr/info.go
+++ b/cmd/youtubedr/info.go
@@ -58,7 +58,7 @@ var infoCmd = &cobra.Command{
 				bitrate = format.Bitrate
 			}
 
-			size, _ := strconv.ParseInt(format.ContentLength, 10, 64)
+			size := format.ContentLength
 			if size == 0 {
 				// Some formats don't have this information
 				size = int64(float64(bitrate) * video.Duration.Seconds() / 8)

--- a/response_data.go
+++ b/response_data.go
@@ -131,7 +131,7 @@ type Format struct {
 	Width            int    `json:"width"`
 	Height           int    `json:"height"`
 	LastModified     string `json:"lastModified"`
-	ContentLength    string `json:"contentLength"`
+	ContentLength    int64  `json:"contentLength,string"`
 	QualityLabel     string `json:"qualityLabel"`
 	ProjectionType   string `json:"projectionType"`
 	AverageBitrate   int    `json:"averageBitrate"`


### PR DESCRIPTION
instead of string

