### PR TITLE
Fetch stream in chunks

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -149,14 +149,13 @@ func getVideoAudioFormats(v *youtube.Video, quality string, mimetype string) (*y
 }
 
 func (dl *Downloader) videoDLWorker(ctx context.Context, out *os.File, video *youtube.Video, format *youtube.Format) error {
-	resp, err := dl.GetStreamContext(ctx, video, format)
+	stream, size, err := dl.GetStreamContext(ctx, video, format)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	prog := &progress{
-		contentLength: float64(resp.ContentLength),
+		contentLength: float64(size),
 	}
 
 	// create progress bar
@@ -175,7 +174,7 @@ func (dl *Downloader) videoDLWorker(ctx context.Context, out *os.File, video *yo
 		),
 	)
 
-	reader := bar.ProxyReader(resp.Body)
+	reader := bar.ProxyReader(stream)
 	mw := io.MultiWriter(out, prog)
 	_, err = io.Copy(mw, reader)
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -19,11 +19,10 @@ func ExampleClient() {
 		panic(err)
 	}
 
-	resp, err := client.GetStream(video, &video.Formats[0])
+	stream, _, err := client.GetStream(video, &video.Formats[0])
 	if err != nil {
 		panic(err)
 	}
-	defer resp.Body.Close()
 
 	file, err := os.Create("video.mp4")
 	if err != nil {
@@ -31,7 +30,7 @@ func ExampleClient() {
 	}
 	defer file.Close()
 
-	_, err = io.Copy(file, resp.Body)
+	_, err = io.Copy(file, stream)
 	if err != nil {
 		panic(err)
 	}
@@ -66,12 +65,11 @@ func ExamplePlaylist() {
 
 	fmt.Printf("Downloading %s by '%s'!\n", video.Title, video.Author)
 
-	resp, err := client.GetStream(video, &video.Formats[0])
+	stream, _, err := client.GetStream(video, &video.Formats[0])
 	if err != nil {
 		panic(err)
 	}
 
-	defer resp.Body.Close()
 	file, err := os.Create("video.mp4")
 
 	if err != nil {
@@ -79,7 +77,7 @@ func ExamplePlaylist() {
 	}
 
 	defer file.Close()
-	_, err = io.Copy(file, resp.Body)
+	_, err = io.Copy(file, stream)
 
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The current code add a `Range` header:

https://github.com/kkdai/youtube/blob/2fc1eef358822a125060af2936e6cd989c617c00/client.go#L151-L153

which helps for small files, but I noticed that after 10 MB, the speed slows down again. As a workaround, you can download the file in 10 MB chunks. Example program:

~~~go
package main

import (
   "github.com/kkdai/youtube/v2"
   "io"
)

func main() {
   var client youtube.Client
   video, err := client.GetVideo("967pHNZk3OM")
   if err != nil {
      panic(err)
   }
   var f youtube.Format
   for _, each := range video.Formats {
      if each.ItagNo == 248 {
         f = each
         break
      }
   }
   client.GetStreamFast(video, &f, io.Discard)
}
~~~