### PR TITLE
Temporary(?) fix for #196

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,7 +40,7 @@ func (c *Client) videoFromID(ctx context.Context, id string) (*Video, error) {
 	// Circumvent age restriction to pretend access through googleapis.com
 	eurl := "https://youtube.googleapis.com/v/" + id
 
-	body, err := c.httpGetBodyBytes(ctx, "https://www.youtube.com/get_video_info?video_id="+id+"&html5=1&eurl="+eurl)
+	body, err := c.httpGetBodyBytes(ctx, "https://www.youtube.com/get_video_info?video_id="+id+"&ps=default&html5=1&c=TVHTML5&cver=7.20201028&eurl="+eurl)
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -95,7 +95,7 @@ func TestGetVideoWithoutManifestURL(t *testing.T) {
 	assert.Equal("rFejpH_tAHM", video.ID)
 	assert.Equal("dotGo 2015 - Rob Pike - Simplicity is Complicated", video.Title)
 	assert.Equal("dotconferences", video.Author)
-	assert.Equal(1392*time.Second, video.Duration)
+	assert.Equal(1391*time.Second, video.Duration)
 	assert.Contains(video.Description, "Go is often described as a simple language.")
 	assert.Equal("2015-12-02 00:00:00 +0000 UTC", video.PublishDate.String())
 }

--- a/video.go
+++ b/video.go
@@ -108,7 +108,7 @@ func (v *Video) extractDataFromPlayerResponse(prData playerResponseData) error {
 	v.Author = prData.VideoDetails.Author
 	v.Thumbnails = prData.VideoDetails.Thumbnail.Thumbnails
 
-	if seconds, _ := strconv.Atoi(prData.Microformat.PlayerMicroformatRenderer.LengthSeconds); seconds > 0 {
+	if seconds, _ := strconv.Atoi(prData.VideoDetails.LengthSeconds); seconds > 0 {
 		v.Duration = time.Duration(seconds) * time.Second
 	}
 


### PR DESCRIPTION
This PR adds some additional parameters to the URL, so that the request returns 200. I've copied them from [pytube](https://github.com/pytube/pytube/blob/9c92997f19e4c61d1dd95399930bb72b946340b7/pytube/extract.py#L231-L241).

The new response is slightly different.
- `Video.Duration` is now taken from `prData.VideoDetails.LengthSeconds`. I do not know why, but it is 1 second less than before, so I also changed the test.
- `Video.PublishDate` is missing. Pytube fetches it from the video page, so I also added a regex to fetch in `parseVideoPage`. `get_video_info` doesn't return this information anymore.

Here is the output of `go test`: https://pastebin.com/9wQvwbJy

You have to decide what to do with the missing values.

Thanks.