### PR TITLE
Fix 403 "Access Denied" for encrypted videos

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,7 +38,7 @@ func (c *Client) GetVideoContext(ctx context.Context, url string) (*Video, error
 }
 
 func (c *Client) videoFromID(ctx context.Context, id string) (*Video, error) {
-	body, err := c.videoDataByInnertube(id)
+	body, err := c.videoDataByInnertube(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,13 @@ type innertubeClient struct {
 	ClientVersion string `json:"clientVersion"`
 }
 
-func (c *Client) videoDataByInnertube(id string) ([]byte, error) {
+func (c *Client) videoDataByInnertube(ctx context.Context, id string) ([]byte, error) {
+	// fetch sts first
+	sts, err := c.getSignatureTimestamp(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
 	// seems like same token for all WEB clients
 	//nolint:gosec
 	const webToken = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
@@ -105,7 +111,7 @@ func (c *Client) videoDataByInnertube(id string) ([]byte, error) {
 		},
 		PlaybackContext: playbackContext{
 			ContentPlaybackContext: contentPlaybackContext{
-				SignatureTimestamp: "18795",
+				SignatureTimestamp: sts,
 			},
 		},
 	}

--- a/client.go
+++ b/client.go
@@ -63,8 +63,17 @@ func (c *Client) videoFromID(ctx context.Context, id string) (*Video, error) {
 }
 
 type innertubeRequest struct {
-	Context inntertubeContext `json:"context"`
-	VideoID string            `json:"videoId"`
+	VideoID         string            `json:"videoId"`
+	Context         inntertubeContext `json:"context"`
+	PlaybackContext playbackContext   `json:"playbackContext"`
+}
+
+type playbackContext struct {
+	ContentPlaybackContext contentPlaybackContext `json:"contentPlaybackContext"`
+}
+
+type contentPlaybackContext struct {
+	SignatureTimestamp string `json:"signatureTimestamp"`
 }
 
 type inntertubeContext struct {
@@ -72,10 +81,10 @@ type inntertubeContext struct {
 }
 
 type innertubeClient struct {
-	BrowserName    string `json:"browserName"`
-	BrowserVersion string `json:"browserVersion"`
-	ClientName     string `json:"clientName"`
-	ClientVersion  string `json:"clientVersion"`
+	HL            string `json:"hl"`
+	GL            string `json:"gl"`
+	ClientName    string `json:"clientName"`
+	ClientVersion string `json:"clientVersion"`
 }
 
 func (c *Client) videoDataByInnertube(id string) ([]byte, error) {
@@ -85,15 +94,20 @@ func (c *Client) videoDataByInnertube(id string) ([]byte, error) {
 	u := fmt.Sprintf("https://www.youtube.com/youtubei/v1/player?key=%s", webToken)
 
 	data := innertubeRequest{
+		VideoID: id,
 		Context: inntertubeContext{
 			Client: innertubeClient{
-				BrowserName:    "Mozilla",
-				BrowserVersion: "5.0",
-				ClientName:     "WEB",
-				ClientVersion:  "2.20210617.01.00",
+				HL:            "en",
+				GL:            "US",
+				ClientName:    "WEB",
+				ClientVersion: "2.20210617.01.00",
 			},
 		},
-		VideoID: id,
+		PlaybackContext: playbackContext{
+			ContentPlaybackContext: contentPlaybackContext{
+				SignatureTimestamp: "18795",
+			},
+		},
 	}
 
 	reqData, err := json.Marshal(data)

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	ErrCipherNotFound             = constError("cipher not found")
+	ErrSignatureTimestampNotFound = constError("signature timestamp not found")
 	ErrInvalidCharactersInVideoID = constError("invalid characters in video id")
 	ErrVideoIDMinLength           = constError("the video id must be at least 10 characters long")
 	ErrReadOnClosedResBody        = constError("http: read on closed response body")

--- a/player_parse.go
+++ b/player_parse.go
@@ -1,0 +1,45 @@
+package youtube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+)
+
+var basejsPattern = regexp.MustCompile(`(/s/player/\w+/player_ias.vflset/\w+/base.js)`)
+
+// we may use \d{5} instead of \d+ since currently its 5 digits, but i can't be sure it will be 5 digits always
+var signatureRegexp = regexp.MustCompile(`(?m)(?:^|,)(?:signatureTimestamp:)(\d+)`)
+
+func (c *Client) fetchPlayerConfig(ctx context.Context, videoID string) ([]byte, error) {
+	embedURL := fmt.Sprintf("https://youtube.com/embed/%s?hl=en", videoID)
+	embedBody, err := c.httpGetBodyBytes(ctx, embedURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// example: /s/player/f676c671/player_ias.vflset/en_US/base.js
+	escapedBasejsURL := string(basejsPattern.Find(embedBody))
+	if escapedBasejsURL == "" {
+		log.Println("playerConfig:", string(embedBody))
+		return nil, errors.New("unable to find basejs URL in playerConfig")
+	}
+
+	return c.httpGetBodyBytes(ctx, "https://youtube.com"+escapedBasejsURL)
+}
+
+func (c *Client) getSignatureTimestamp(ctx context.Context, videoID string) (string, error) {
+	basejsBody, err := c.fetchPlayerConfig(ctx, videoID)
+	if err != nil {
+		return "", err
+	}
+
+	result := signatureRegexp.FindSubmatch(basejsBody)
+	if result == nil {
+		return "", ErrSignatureTimestampNotFound
+	}
+
+	return string(result[1]), nil
+}


### PR DESCRIPTION
# Description

Turns out, request without `playbackContext` and, in particular, `signatureTimestamp` always lead to 403 "Access Denied" after decrypting signature. This value seems like doesn't change too often, so temporarily hard-coding it just to fix problem as soon as possible. But later need to fetch it from youtube.

I don't know how often this `signatureTimestamp` changes, but i tried few different videos from different browsers and it was `18795` every time. Probably should work at least until tomorrow. 

Its possible to get this value from player js (same as decipher options). Need to look for `sts` or `signatureTimestamp` (its stored several times). Though, this require a bit more changes in code (and possibly rearrangements), so i decided to make this small temporary fix for now.

Also browser metadata isn't mandatory for request, instead its better to specify language so server responses always be same instead of server changing response language based on your ip.

## Issues to fix

Please link issues this PR will fix: \
https://github.com/kkdai/youtube/pull/198#issuecomment-865706356

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
