### PR TITLE
Simple age-restricted videos bypass

### DIFF
--- a/client.go
+++ b/client.go
@@ -75,6 +75,11 @@ func (c *Client) videoFromID(ctx context.Context, id string) (*Video, error) {
 			return v, nil
 		}
 
+		// private video clearly not age-restricted and thus should be explicit
+		if errEmbed == ErrVideoPrivate {
+			return v, errEmbed
+		}
+
 		// wrapping error so its clear whats happened
 		return v, fmt.Errorf("can't bypass age restriction: %w", errEmbed)
 	}
@@ -145,7 +150,7 @@ var innertubeClientInfo = map[string]map[string]string{
 	// might add ANDROID and other in future, but i don't see reason yet
 	"WEB": {
 		"version": "2.20210617.01.00",
-		"key": "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8",
+		"key":     "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8",
 	},
 	"WEB_EMBEDDED_PLAYER": {
 		"version": "1.19700101",

--- a/errors.go
+++ b/errors.go
@@ -11,6 +11,7 @@ const (
 	ErrVideoIDMinLength           = constError("the video id must be at least 10 characters long")
 	ErrReadOnClosedResBody        = constError("http: read on closed response body")
 	ErrNotPlayableInEmbed         = constError("embedding of this video has been disabled")
+	ErrLoginRequired              = constError("login required to confirm your age")
 	ErrInvalidPlaylist            = constError("no playlist detected or invalid playlist ID")
 )
 

--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,7 @@ const (
 	ErrReadOnClosedResBody        = constError("http: read on closed response body")
 	ErrNotPlayableInEmbed         = constError("embedding of this video has been disabled")
 	ErrLoginRequired              = constError("login required to confirm your age")
+	ErrVideoPrivate               = constError("user restricted access to this video")
 	ErrInvalidPlaylist            = constError("no playlist detected or invalid playlist ID")
 )
 

--- a/video.go
+++ b/video.go
@@ -72,6 +72,10 @@ func (v *Video) isVideoDownloadable(prData playerResponseData, isVideoPage bool)
 		return nil
 	}
 
+	if prData.PlayabilityStatus.Status == "LOGIN_REQUIRED" {
+		return ErrLoginRequired
+	}
+
 	if !isVideoPage && !prData.PlayabilityStatus.PlayableInEmbed {
 		return ErrNotPlayableInEmbed
 	}

--- a/video.go
+++ b/video.go
@@ -73,6 +73,10 @@ func (v *Video) isVideoDownloadable(prData playerResponseData, isVideoPage bool)
 	}
 
 	if prData.PlayabilityStatus.Status == "LOGIN_REQUIRED" {
+		// for some reason they use same status message for age-restricted and private videos
+		if prData.PlayabilityStatus.Reason == "This video is private." {
+			return ErrVideoPrivate
+		}
 		return ErrLoginRequired
 	}
 

--- a/video_test.go
+++ b/video_test.go
@@ -94,7 +94,7 @@ func TestDownload_WhenPlayabilityStatusIsNotOK(t *testing.T) {
 		{
 			issue:   "issue#59",
 			videoID: "nINQjT7Zr9w",
-			err:     `status: LOGIN_REQUIRED`,
+			err:     ErrVideoPrivate.Error(),
 		},
 	}
 


### PR DESCRIPTION
# Description

Now `videoDataByInnertube` can accept `ClientName` as 3rd, optional arguement, If this argument == `embed` => we should pretend to be embed client and name themselves as `WEB_EMBEDDED_PLAYER`. Any other value will make us use default client name (i.e.  `WEB`), since no more clients is needed _yet_.
Besides of that, prepared code to be reusable with different clients in future (but didn't add any of them yet without reason).

In result of made changes, its now possible to distinguish age-restricted videos from private videos. Latter is never possible for us to fetch, so i introduced additional error to explicitly tell that to user.

## Issues to fix

Please link issues this PR will fix: \
\#202

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
