### PR TITLE
Fix bug 206: No audio when downloading programatically

### DIFF
--- a/cmd/youtubedr/downloader.go
+++ b/cmd/youtubedr/downloader.go
@@ -88,13 +88,13 @@ func getVideoWithFormat(id string) (*youtube.Video, *youtube.Format, error) {
 	switch {
 	case itag > 0:
 		// When an itag is specified, do not filter format with mime-type
-		format = video.Formats.FindByItag(itag)
+		format = video.Formats.WithAudioChannels().FindByItag(itag)
 		if format == nil {
 			return nil, nil, fmt.Errorf("unable to find format with itag %d", itag)
 		}
 
 	case outputQuality != "":
-		format = formats.FindByQuality(outputQuality)
+		format = formats.WithAudioChannels().FindByQuality(outputQuality)
 		if format == nil {
 			return nil, nil, fmt.Errorf("unable to find format with quality %s", outputQuality)
 		}

--- a/format_list.go
+++ b/format_list.go
@@ -60,6 +60,16 @@ func (list FormatList) AudioChannels(n int) (result FormatList) {
 	return result
 }
 
+// AudioChannels returns a new FormatList filtered by the matching AudioChannels
+func (list FormatList) WithAudioChannels() (result FormatList) {
+	for _, f := range list {
+		if f.AudioChannels > 0 {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
 // FilterQuality reduces the format list to formats matching the quality
 func (v *Video) FilterQuality(quality string) {
 	v.Formats = v.Formats.Quality(quality)

--- a/format_list_test.go
+++ b/format_list_test.go
@@ -168,11 +168,12 @@ func TestFormatList_Sort(t *testing.T) {
 }
 
 func TestFormatList_WithAudioChannels(t *testing.T) {
-	list := []Format{{
-		AudioChannels: 0,
-		Quality:       "medium",
-		QualityLabel:  "360p",
-	},
+	list := []Format{
+		{
+			AudioChannels: 0,
+			Quality:       "medium",
+			QualityLabel:  "360p",
+		},
 		{
 			AudioChannels: 1,
 			Quality:       "large",
@@ -182,7 +183,7 @@ func TestFormatList_WithAudioChannels(t *testing.T) {
 	tests := []struct {
 		name string
 		list FormatList
-		want []Format
+		want FormatList
 	}{
 		{
 			name: "find all formats with Audio Channels",

--- a/format_list_test.go
+++ b/format_list_test.go
@@ -166,3 +166,40 @@ func TestFormatList_Sort(t *testing.T) {
 
 	// TODO add more tests here
 }
+
+func TestFormatList_WithAudioChannels(t *testing.T) {
+	list := []Format{{
+		AudioChannels: 0,
+		Quality:       "medium",
+		QualityLabel:  "360p",
+	},
+		{
+			AudioChannels: 1,
+			Quality:       "large",
+			QualityLabel:  "480p",
+		},
+	}
+	tests := []struct {
+		name string
+		list FormatList
+		want []Format
+	}{
+		{
+			name: "find all formats with Audio Channels",
+			list: list,
+			want: []Format{
+				{
+					AudioChannels: 1,
+					Quality:       "large",
+					QualityLabel:  "480p",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format := tt.list.WithAudioChannels()
+			assert.Equal(t, format, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Filter out formats without audio channels before choosing one format for download.

## Issues to fix

Please link issues this PR will fix: \
\#_[206]_

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
