### PR TITLE
remove audio channel filter when using itag

### DIFF
--- a/cmd/youtubedr/downloader.go
+++ b/cmd/youtubedr/downloader.go
@@ -88,7 +88,7 @@ func getVideoWithFormat(id string) (*youtube.Video, *youtube.Format, error) {
 	switch {
 	case itag > 0:
 		// When an itag is specified, do not filter format with mime-type
-		format = video.Formats.WithAudioChannels().FindByItag(itag)
+		format = video.Formats.FindByItag(itag)
 		if format == nil {
 			return nil, nil, fmt.Errorf("unable to find format with itag %d", itag)
 		}


### PR DESCRIPTION
# Description

remove audio channel filter when using itag(introduce by #207 for quality like medium, but not for itag)

## Issues to fix

Please link issues this PR will fix: \
#210 


