### PR TITLE
Fix decipher (n-function name extraction)

### DIFF
--- a/decipher.go
+++ b/decipher.go
@@ -65,7 +65,7 @@ const (
 )
 
 var (
-	nFunctionNameRegexp = regexp.MustCompile("\\.get\\(\"n\"\\)\\)&&\\(b=([a-zA-Z0-9]+)\\(b\\)")
+	nFunctionNameRegexp = regexp.MustCompile("\\.get\\(\"n\"\\)\\)&&\\(b=([a-zA-Z0-9]{3})\\[(\\d+)\\](.+)\\|\\|([a-zA-Z0-9]{3})")
 	actionsObjRegexp    = regexp.MustCompile(fmt.Sprintf(
 		"var (%s)=\\{((?:(?:%s%s|%s%s|%s%s),?\\n?)+)\\};", jsvarStr, jsvarStr, swapStr, jsvarStr, spliceStr, jsvarStr, reverseStr))
 
@@ -113,7 +113,13 @@ func (config playerConfig) getNFunction() (string, error) {
 	if len(nameResult) == 0 {
 		return "", errors.New("unable to extract n-function name")
 	}
-	name := string(nameResult[1])
+
+	var name string
+	if idx, _ := strconv.Atoi(string(nameResult[2])); idx == 0 {
+		name = string(nameResult[4])
+	} else {
+		name = string(nameResult[1])
+	}
 
 	// find the beginning of the function
 	def := []byte(name + "=function(")


### PR DESCRIPTION
# Description

- Updated `var nFunctionNameRegexp` in decipher
- Updated `func getNFunction` in decipher

## Issues to fix

Please link issues this PR will fix: \
\#_[235]_

if no relevant issue, but this will fix something important for reference
, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
