### PR TITLE
decipher: fix n-function name regex

### DIFF
--- a/decipher.go
+++ b/decipher.go
@@ -66,7 +66,7 @@ const (
 )
 
 var (
-	nFunctionNameRegexp = regexp.MustCompile("\\.get\\(\"n\"\\)\\)&&\\(b=([a-zA-Z0-9]{3})\\[(\\d+)\\](.+)\\|\\|([a-zA-Z0-9]{3})")
+	nFunctionNameRegexp = regexp.MustCompile("\\.get\\(\"n\"\\)\\)&&\\(b=([a-zA-Z0-9$]{0,3})\\[(\\d+)\\](.+)\\|\\|([a-zA-Z0-9]{0,3})")
 	actionsObjRegexp    = regexp.MustCompile(fmt.Sprintf(
 		"var (%s)=\\{((?:(?:%s%s|%s%s|%s%s),?\\n?)+)\\};", jsvarStr, jsvarStr, swapStr, jsvarStr, spliceStr, jsvarStr, reverseStr))
 


### PR DESCRIPTION
# Description

This PR fixes an issue with the `nFunctionNameRegexp` failing to find the n function: `unable to extract n-function name`

## Issues to fix

Please link issues this PR will fix: 
#240

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
