### PR TITLE
Unthrottle streams for all formats

### DIFF
--- a/client.go
+++ b/client.go
@@ -298,7 +298,7 @@ func (c *Client) GetStreamURL(video *Video, format *Format) (string, error) {
 // GetStreamURLContext returns the url for a specific format with a context
 func (c *Client) GetStreamURLContext(ctx context.Context, video *Video, format *Format) (string, error) {
 	if format.URL != "" {
-		return format.URL, nil
+		return c.unThrottle(ctx, video.ID, format.URL)
 	}
 
 	cipher := format.Cipher

--- a/decipher.go
+++ b/decipher.go
@@ -37,19 +37,55 @@ func (c *Client) decipherURL(ctx context.Context, videoID string, cipher string)
 	}
 	query.Add(params.Get("sp"), string(bs))
 
-	// decrypt n-parameter
-	nSig := query.Get("n")
-	if nSig != "" {
-		nDecoded, err := config.decodeNsig(nSig)
-		if err != nil {
-			return "", fmt.Errorf("unable to decode nSig: %w", err)
-		}
-		query.Set("n", nDecoded)
+	query, err = c.decryptNParam(ctx, config, query)
+	if err != nil {
+		return "", err
 	}
 
 	uri.RawQuery = query.Encode()
 
 	return uri.String(), nil
+}
+
+func (c *Client) unThrottle(ctx context.Context, videoID string, urlString string) (string, error) {
+	config, err := c.getPlayerConfig(ctx, videoID)
+	if err != nil {
+		return "", err
+	}
+	uri, err := url.Parse(urlString)
+	if err != nil {
+		return "", err
+	}
+
+	query, err := c.decryptNParam(ctx, config, uri.Query())
+	if err != nil {
+		return "", err
+	}
+
+	uri.RawQuery = query.Encode()
+
+	return uri.String(), nil
+
+}
+
+func (c *Client) decryptNParam(ctx context.Context, config playerConfig, query url.Values) (url.Values, error) {
+
+	// decrypt n-parameter
+	nSig := query.Get("n")
+	if nSig != "" {
+		nDecoded, err := config.decodeNsig(nSig)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode nSig: %w", err)
+		}
+		query.Set("n", nDecoded)
+	}
+
+	if c.Debug {
+		log.Printf("[nParam] n: %s; nDecoded: %s\nQuery: %v\n", nSig, query.Get("n"), query)
+	}
+
+	return query, nil
+
 }
 
 const (


### PR DESCRIPTION
## Description

The n-param potentially requires processing even if there's no
deciphering needed.
Refactor decipherURL to reuse decryptNParam on any url.


## Issues to Fix

https://github.com/kkdai/youtube/issues/230

https://github.com/kkdai/youtube/issues/232

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
