### PR TITLE
Instructions using go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This tool is meant to be used to download CC0 licenced content, we do not suppor
 Please ensure you have installed Go 1.18 or later.
 
 ```shell
-go get github.com/kkdai/youtube/v2
+go install github.com/kkdai/youtube/v2@latest
 ```
 
 ### From source code

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ This tool is meant to be used to download CC0 licenced content, we do not suppor
 Please ensure you have installed Go 1.18 or later.
 
 ```shell
-go install github.com/kkdai/youtube/v2@latest
 ```
 
 ### From source code


### PR DESCRIPTION
# Description

Just updated the installation instructions.

**This does not work:**
```
❯ go get github.com/kkdai/youtube/v28
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

**This works:**
```
❯ go install github.com/kkdai/youtube/v2/cmd/youtubedr@latest
go: downloading github.com/kkdai/youtube/v2 v2.7.18
go: downloading golang.org/x/net v0.2.0
go: downloading github.com/spf13/viper v1.14.0
go: downloading github.com/spf13/cobra v1.6.1
go: downloading github.com/vbauerster/mpb/v5 v5.4.0
go: downloading github.com/bitly/go-simplejson v0.5.0
go: downloading github.com/dop251/goja v0.0.0-20221115122301-6c0d9883792e
go: downloading github.com/mattn/go-runewidth v0.0.14
go: downloading github.com/rivo/uniseg v0.4.3
go: downloading github.com/spf13/afero v1.9.3
go: downloading github.com/fsnotify/fsnotify v1.6.0
go: downloading github.com/pelletier/go-toml/v2 v2.0.6
go: downloading github.com/VividCortex/ewma v1.2.0
go: downloading github.com/dlclark/regexp2 v1.7.0
go: downloading github.com/go-sourcemap/sourcemap v2.1.3+incompatible
```


## Issues to fix

fixes #150 
