### PR TITLE
Add ChannelHandle to Video struct

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 var testClient = Client{Debug: true}
+var testWebClient = Client{Debug: true, client: &WebClient}
 
 const (
 	dwlURL    string = "https://www.youtube.com/watch?v=rFejpH_tAHM"
@@ -104,6 +105,34 @@ func TestGetVideoWithoutManifestURL(t *testing.T) {
 
 	// Publishing date doesn't seem to be present in android client
 	// assert.Equal("2015-12-02 00:00:00 +0000 UTC", video.PublishDate.String())
+}
+
+func TestWebClientGetVideoWithoutManifestURL(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+
+	video, err := testWebClient.GetVideo(dwlURL)
+	require.NoError(err, "get video")
+	require.NotNil(video)
+
+	assert.NotEmpty(video.Thumbnails)
+	assert.Greater(len(video.Thumbnails), 0)
+	assert.NotEmpty(video.Thumbnails[0].URL)
+	assert.Empty(video.HLSManifestURL)
+	assert.Empty(video.DASHManifestURL)
+
+	assert.NotEmpty(video.CaptionTracks)
+	assert.Greater(len(video.CaptionTracks), 0)
+	assert.NotEmpty(video.CaptionTracks[0].BaseURL)
+
+	assert.Equal("rFejpH_tAHM", video.ID)
+	assert.Equal("dotGo 2015 - Rob Pike - Simplicity is Complicated", video.Title)
+	assert.Equal("dotconferences", video.Author)
+	assert.GreaterOrEqual(video.Duration, 1390*time.Second)
+	assert.Contains(video.Description, "Go is often described as a simple language.")
+
+	// Publishing date and channel handle are present in web client
+	assert.Equal("2015-12-02 00:00:00 +0000 UTC", video.PublishDate.String())
+	assert.Equal("@dotconferences", video.ChannelHandle)
 }
 
 func TestGetVideoWithManifestURL(t *testing.T) {

--- a/video.go
+++ b/video.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -17,6 +18,7 @@ type Video struct {
 	Description     string
 	Author          string
 	ChannelID       string
+	ChannelHandle   string
 	Views           int
 	Duration        time.Duration
 	PublishDate     time.Time
@@ -115,6 +117,10 @@ func (v *Video) extractDataFromPlayerResponse(prData playerResponseData) error {
 
 	if str := prData.Microformat.PlayerMicroformatRenderer.PublishDate; str != "" {
 		v.PublishDate, _ = time.Parse(dateFormat, str)
+	}
+
+	if profileUrl, err := url.Parse(prData.Microformat.PlayerMicroformatRenderer.OwnerProfileURL); err == nil && len(profileUrl.Path) > 1 {
+		v.ChannelHandle = profileUrl.Path[1:]
 	}
 
 	// Assign Streams

--- a/video.go
+++ b/video.go
@@ -119,8 +119,8 @@ func (v *Video) extractDataFromPlayerResponse(prData playerResponseData) error {
 		v.PublishDate, _ = time.Parse(dateFormat, str)
 	}
 
-	if profileUrl, err := url.Parse(prData.Microformat.PlayerMicroformatRenderer.OwnerProfileURL); err == nil && len(profileUrl.Path) > 1 {
-		v.ChannelHandle = profileUrl.Path[1:]
+	if profileURL, err := url.Parse(prData.Microformat.PlayerMicroformatRenderer.OwnerProfileURL); err == nil && len(profileURL.Path) > 1 {
+		v.ChannelHandle = profileURL.Path[1:]
 	}
 
 	// Assign Streams


### PR DESCRIPTION
# Description

Adds `ChannelHandle` to `Video` struct.

It may be useful to some using this package to be able to access the channel handle on a video in addition to the channel's display name and ID. The handle comes from `playerResponseData.Microformat.PlayerMicroformatRenderer.OwnerProfileURL` (which is in the format `http://www.youtube.com/@handle`) and thus is empty when using the Android client. 
