### PR TITLE
fix 100mb download limit

### DIFF
--- a/client.go
+++ b/client.go
@@ -375,23 +375,9 @@ func (c *Client) getChunkSize() int64 {
 	return Size10Mb
 }
 
-func (c *Client) getMaxRoutines(limit int) int {
-	routines := 10
-
-	if c.MaxRoutines > 0 {
-		routines = c.MaxRoutines
-	}
-
-	if limit > 0 && routines > limit {
-		routines = limit
-	}
-
-	return routines
-}
-
 func (c *Client) downloadChunked(ctx context.Context, req *http.Request, w *io.PipeWriter, format *Format) {
 	chunks := getChunks(format.ContentLength, c.getChunkSize())
-	maxRoutines := c.getMaxRoutines(len(chunks))
+	maxRoutines := len(chunks)
 
 	cancelCtx, cancel := context.WithCancel(ctx)
 	abort := func(err error) {


### PR DESCRIPTION
# Description

Remove getmaxRoutines(and just return parameter)

```go
func (c *Client) getMaxRoutines(limit int) int {
	routines := 10

	if c.MaxRoutines > 0 {
		routines = c.MaxRoutines
	}

	if limit > 0 && routines > limit {
		routines = limit
	}

	return routines
}
```

This function simply limits MaxRoutines to 10.

Since each chunk is 10MB, the maximum download size is limited to 100MB.

So I removed the download size limit by deleting the function.

## Issues to fix

Please link issues this PR will fix: 
#298 

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
