### PR TITLE
Add audioTrack support

### DIFF
--- a/response_data.go
+++ b/response_data.go
@@ -117,6 +117,13 @@ type Format struct {
 		Start string `json:"start"`
 		End   string `json:"end"`
 	} `json:"indexRange"`
+
+	// AudioTrack is only available for videos with multiple audio track languages
+	AudioTrack *struct {
+		DisplayName    string `json:"displayName"`
+		ID             string `json:"id"`
+		AudioIsDefault bool   `json:"audioIsDefault"`
+	}
 }
 
 type Thumbnails []Thumbnail


### PR DESCRIPTION
# Description

Add support for the format `audioTrack` metadata property, as well as the change the format list sorting algorithm to sort by the `audioTrack.audioIsDefault` property first (and then use the previous sorting logic for everything else), meaning that all audio tracks for the default language will be ordered before any audio tracks for other languages.

## Issues to fix

Please link issues this PR will fix: #314

If no relevant issue, but this will fix something important for reference, please free to open an issue.

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
