### PR TITLE
fix precondition check failed error

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,9 +182,9 @@ var (
 	// AndroidClient, download go brrrrrr.
 	AndroidClient = clientInfo{
 		name:           "ANDROID",
-		version:        "17.31.35",
+		version:        "18.11.34",
 		key:            "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w",
-		userAgent:      "com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip",
+		userAgent:      "com.google.android.youtube/18.11.34 (Linux; U; Android 11) gzip",
 		androidVersion: 30,
 	}
 


### PR DESCRIPTION
# Description

Updated `clientVersion` for Android client from `17.31.35` to `18.11.34`.

I'm getting an error `unexpected status code: 400` while getting info or downloading any video as mentioned by some users in #320. I did some digging by replicating the request made by http client in postman and got this response.

```json
{
    "error": {
        "code": 400,
        "message": "Precondition check failed.",
        "errors": [
            {
                "message": "Precondition check failed.",
                "domain": "global",
                "reason": "failedPrecondition"
            }
        ],
        "status": "FAILED_PRECONDITION"
    }
}
```

This is related to the issue [here](https://github.com/yt-dlp/yt-dlp/issues/9316). Luckily, @bashonly has already provided a patch at comment https://github.com/yt-dlp/yt-dlp/issues/9316#issuecomment-1969319360 at commit https://github.com/bashonly/yt-dlp/commit/f2e86a3f6d8a016e98d678fa47ecb94de23cbfa0. I tried replicating same patch in go youtube client and they appear to be working on machine. 

Fixes: #320
