### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,19 @@ This tool is meant to be used to download CC0 licenced content, we do not suppor
 
 ## Installation
 
-### Install via go get
+### Run Manually
+
+```shell
+git clone https://github.com/kkdai/youtube.git && cd youtube
+go run ./cmd/youtubedr
+```
+
+### Install via Go
 
 Please ensure you have installed Go 1.21 or later.
 
 ```shell
-go get github.com/kkdai/youtube/v2
-```
-
-### From source code
-
-```shell
-git clone https://github.com/kkdai/youtube.git
-cd youtube
-go run ./cmd/youtubedr
+go install github.com/kkdai/youtube/v2/cmd/youtubedr@latest
 ```
 
 ### Mac
@@ -56,8 +55,8 @@ pkg install youtubedr
 It's really simple to use, just get the video id from youtube url - ex: `https://www.youtube.com/watch?v=rFejpH_tAHM`, the video id is `rFejpH_tAHM`
 
 ```shell
-$ youtubedr download QAGDGja7kbs
-$ youtubedr download https://www.youtube.com/watch?v=rFejpH_tAHM
+youtubedr download rFejpH_tAHM
+youtubedr download https://www.youtube.com/watch?v=rFejpH_tAHM
 ```
 
 
@@ -68,8 +67,6 @@ Please check out the [example_test.go](example_test.go) for example code.
 
 ## Example:
  * ### Get information of dotGo-2015-rob-pike video for downloading
-
-    `go get github.com/kkdai/youtube/v2/youtubedr`
 
     Download video from [dotGo 2015 - Rob Pike - Simplicity is Complicated](https://www.youtube.com/watch?v=rFejpH_tAHM)
 
@@ -87,8 +84,6 @@ Please check out the [example_test.go](example_test.go) for example code.
     ```
  * ### Download dotGo-2015-rob-pike-video
 
-    `go get github.com/kkdai/youtube/v2/youtubedr`
-
     Download video from [dotGo 2015 - Rob Pike - Simplicity is Complicated](https://www.youtube.com/watch?v=rFejpH_tAHM)
 
     ```
@@ -97,8 +92,6 @@ Please check out the [example_test.go](example_test.go) for example code.
 
  * ### Download video to specific folder and name
 
-	`go get github.com/kkdai/youtube/v2/youtubedr`
-
 	Download video from [dotGo 2015 - Rob Pike - Simplicity is Complicated](https://www.youtube.com/watch?v=rFejpH_tAHM) to current directory and name the file to simplicity-is-complicated.mp4
 
 	```
@@ -106,8 +99,6 @@ Please check out the [example_test.go](example_test.go) for example code.
 	```
 
  * ### Download video with specific quality
-
-	`go get github.com/kkdai/youtube/v2/youtubedr`
 
 	Download video from [dotGo 2015 - Rob Pike - Simplicity is Complicated](https://www.youtube.com/watch?v=rFejpH_tAHM) with specific quality
 
@@ -124,8 +115,6 @@ Please check out the [example_test.go](example_test.go) for example code.
 
 
  * ### Download video with specific itag
-
-    `go get github.com/kkdai/youtube/v2/youtubedr`
 
     Download video from [dotGo 2015 - Rob Pike - Simplicity is Complicated](https://www.youtube.com/watch?v=rFejpH_tAHM)
 


### PR DESCRIPTION
# Description

- removed `go get URL` information for installation as it is no longer used after [1.16](https://tip.golang.org/doc/go1.16#modules)
- added `go install URL` note 
- corrected the first usage example by using the same ID as an argument for consistency

## Issues to fix

this PR doesn't require an issue, it is just my observation to make getting started easier without ambiguity


