### PR TITLE
Pass visitorData to requests

### DIFF
--- a/protobuilder.go
+++ b/protobuilder.go
@@ -1,0 +1,73 @@
+package youtube
+
+import (
+	"bytes"
+	"encoding/base64"
+	"net/url"
+)
+
+type ProtoBuilder struct {
+	byteBuffer bytes.Buffer
+}
+
+func (pb *ProtoBuilder) ToBytes() []byte {
+	return pb.byteBuffer.Bytes()
+}
+
+func (pb *ProtoBuilder) ToUrlEncodedBase64() string {
+	b64 := base64.URLEncoding.EncodeToString(pb.ToBytes())
+	return url.QueryEscape(b64)
+}
+
+func (pb *ProtoBuilder) writeVarint(val int64) error {
+	if val == 0 {
+		_, err := pb.byteBuffer.Write([]byte{0})
+		return err
+	}
+	for {
+		b := byte(val & 0x7F)
+		val >>= 7
+		if val != 0 {
+			b |= 0x80
+		}
+		_, err := pb.byteBuffer.Write([]byte{b})
+		if err != nil {
+			return err
+		}
+		if val == 0 {
+			break
+		}
+	}
+	return nil
+}
+
+func (pb *ProtoBuilder) field(field int, wireType byte) error {
+	val := int64(field<<3) | int64(wireType&0x07)
+	return pb.writeVarint(val)
+}
+
+func (pb *ProtoBuilder) Varint(field int, val int64) error {
+	err := pb.field(field, 0)
+	if err != nil {
+		return err
+	}
+	return pb.writeVarint(val)
+}
+
+func (pb *ProtoBuilder) String(field int, stringVal string) error {
+	strBts := []byte(stringVal)
+	return pb.Bytes(field, strBts)
+}
+
+func (pb *ProtoBuilder) Bytes(field int, bytesVal []byte) error {
+	if err := pb.field(field, 2); err != nil {
+		return err
+	}
+
+	if err := pb.writeVarint(int64(len(bytesVal))); err != nil {
+		return err
+	}
+
+	_, err := pb.byteBuffer.Write(bytesVal)
+	return err
+}

--- a/protobuilder_test.go
+++ b/protobuilder_test.go
@@ -1,0 +1,18 @@
+package youtube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtoBuilder(t *testing.T) {
+	var pb ProtoBuilder
+
+	pb.Varint(1, 128)
+	pb.Varint(2, 1234567890)
+	pb.Varint(3, 1234567890123456789)
+	pb.String(4, "Hello")
+	pb.Bytes(5, []byte{1, 2, 3})
+	assert.Equal(t, "CIABENKF2MwEGJWCpu_HnoSRESIFSGVsbG8qAwECAw%3D%3D", pb.ToUrlEncodedBase64())
+}


### PR DESCRIPTION
# Description

Pass `visitorData` to requests emitted by the client.

This is a nearly verbatim copy of a [similar PR](https://github.com/TeamNewPipe/NewPipeExtractor/pull/1262) from NewPipe as it is also affected by the same issue, for now the code is pretty rough and I'm not even sure that this data should be passed for all requests but it does seem to unblock the iOS client for now.

## Issues to fix

Please link issues this PR will fix: #354 

## Reminding
Something you can do before PR to reduce time to merge

* run "make build" to build the code
* run "make format" to reformat the code
* run "make lint" if you are using unix system
* run "make test-integration" to pass all tests 
