### PR TITLE
fix(playlist): don't panic on entries with empty lengthSeconds

### DIFF
--- a/playlist.go
+++ b/playlist.go
@@ -229,10 +229,10 @@ type videosJSONExtractor struct {
 }
 
 func (vje videosJSONExtractor) PlaylistEntry() *PlaylistEntry {
-	ds, err := strconv.Atoi(vje.Renderer.Duration)
-	if err != nil {
-		panic("invalid video duration: " + vje.Renderer.Duration)
-	}
+	// A live, premiere, or unavailable (private/deleted) playlist entry has no
+	// lengthSeconds. Parse leniently (0 when absent) rather than panicking, so a
+	// single such entry doesn't abort parsing of the whole playlist.
+	ds, _ := strconv.Atoi(vje.Renderer.Duration)
 	return &PlaylistEntry{
 		ID:         vje.Renderer.ID,
 		Title:      vje.Renderer.Title.String(),


### PR DESCRIPTION
## Problem

`videosJSONExtractor.PlaylistEntry()` calls `strconv.Atoi(vje.Renderer.Duration)` and **panics** when the duration can't be parsed:

```go
ds, err := strconv.Atoi(vje.Renderer.Duration)
if err != nil {
    panic("invalid video duration: " + vje.Renderer.Duration)
}
```

A playlist entry that is a **live stream, premiere, or unavailable (private / deleted / region-blocked) video** carries an empty `lengthSeconds`. `strconv.Atoi("")` errors, so the panic fires; `parsePlaylistInfo` recovers it into:

```
JSON parsing error: invalid video duration:
```

The result is that **a single such entry makes `GetPlaylist`/`GetPlaylistContext` fail for the entire playlist**, even though every other entry is perfectly playable. This is common — many auto-collected music/radio playlists contain at least one unavailable item.

### Repro
Fetch any playlist containing a private/deleted/live entry (e.g. a long music/radio mix). On `master` it returns `invalid video duration:` and no videos.

## Fix

Parse the duration leniently (`0` when absent) instead of panicking, so one durationless entry no longer aborts the whole playlist:

```go
ds, _ := strconv.Atoi(vje.Renderer.Duration)
```

`PlaylistEntry.Duration` is simply `0` for those entries — the natural value for a live/unavailable item. All other fields (ID, title, author, thumbnails) are populated as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)